### PR TITLE
feat: change timeout to use seconds instead of minutes

### DIFF
--- a/integration-tests/stacks/configs/timeout/stacks/timeout.yml
+++ b/integration-tests/stacks/configs/timeout/stacks/timeout.yml
@@ -1,7 +1,7 @@
 commandRole: arn:aws:iam::{{ env.TKM_ORG_A_ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
 regions: eu-north-1
 name: timeout
-timeout: 1
+timeout: 60
 parameters:
   CreateWaitCondition: {{ var.create_wait_condition }}
   CreateSecondTopic: {{ var.create_second_topic }}

--- a/packages/takomo-aws-clients/src/cloudformation.ts
+++ b/packages/takomo-aws-clients/src/cloudformation.ts
@@ -218,7 +218,7 @@ export class CloudFormationClient extends AwsClient<CloudFormation> {
 
         if (timeoutConfig.timeout !== 0) {
           const elapsedTime = Date.now() - timeoutConfig.startTime
-          if (elapsedTime > timeoutConfig.timeout * 60 * 1000) {
+          if (elapsedTime > timeoutConfig.timeout * 1000) {
             if (cfStack.StackStatus === "UPDATE_IN_PROGRESS") {
               const cancelClientToken = await this.cancelStackUpdate(stackName)
               return this.waitUntilStackCreateOrUpdateCompletes(


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/aws-clients

BREAKING CHANGE:
Timeout is now configured in seconds instead of minutes

ISSUES CLOSED: #15