### PR TITLE
feat: add projectDir property to config sets

### DIFF
--- a/integration-tests/deployment-targets/configs/deployment/targets-3.yml
+++ b/integration-tests/deployment-targets/configs/deployment/targets-3.yml
@@ -1,0 +1,15 @@
+deploymentGroups:
+  GroupA/Child:
+    configSets: example
+    targets:
+      - name: one
+        deploymentRole: arn:aws:iam::{{ env.TKM_ORG_A_ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+      - name: two
+        deploymentRole: arn:aws:iam::{{ env.TKM_ORG_A_ACCOUNT_2_ID }}:role/OrganizationAccountAccessRole
+
+configSets:
+  example:
+    description: Example configs
+    projectDir: others
+    commandPaths:
+      - /example.yml/eu-west-1

--- a/integration-tests/deployment-targets/configs/others/stacks/example.yml
+++ b/integration-tests/deployment-targets/configs/others/stacks/example.yml
@@ -1,0 +1,1 @@
+regions: eu-west-1

--- a/integration-tests/deployment-targets/configs/others/templates/example.yml
+++ b/integration-tests/deployment-targets/configs/others/templates/example.yml
@@ -1,0 +1,4 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: {}

--- a/integration-tests/deployment-targets/jest.config.json
+++ b/integration-tests/deployment-targets/jest.config.json
@@ -1,5 +1,6 @@
 {
   "testEnvironment": "node",
   "testRegex": ["/test/.*\\.(test)?\\.(ts)$"],
-  "moduleFileExtensions": ["ts", "js", "json", "node"]
+  "moduleFileExtensions": ["ts", "js", "json", "node"],
+  "setupFiles": ["./jest.setup.js"]
 }

--- a/integration-tests/deployment-targets/test/deploy-with-project-dir.test.ts
+++ b/integration-tests/deployment-targets/test/deploy-with-project-dir.test.ts
@@ -1,0 +1,105 @@
+import { initOptionsAndVariables } from "@takomo/cli"
+import { CliUndeployTargetsIO } from "@takomo/cli-io"
+import { CommandStatus, DeploymentOperation, Options } from "@takomo/core"
+import { deploymentTargetsOperationCommand } from "@takomo/deployment-targets"
+import { TestDeployStacksIO, TestUndeployStacksIO } from "./io"
+import { TIMEOUT } from "./test-constants"
+
+const createOptions = async () =>
+  initOptionsAndVariables({
+    log: "info",
+    yes: true,
+    dir: "configs",
+  })
+
+describe("Deployment with project dir", () => {
+  it(
+    "undeploy all",
+    async () => {
+      const { options, variables, watch } = await createOptions()
+
+      const {
+        results,
+        status,
+        success,
+      } = await deploymentTargetsOperationCommand(
+        {
+          operation: DeploymentOperation.UNDEPLOY,
+          targets: [],
+          groups: [],
+          configFile: "targets-3.yml",
+          options,
+          variables,
+          watch,
+        },
+        new CliUndeployTargetsIO(
+          options,
+          (options: Options, loggerName: string) =>
+            new TestDeployStacksIO(options),
+          (options: Options, loggerName: string) =>
+            new TestUndeployStacksIO(options),
+        ),
+      )
+
+      expect(results).toHaveLength(1)
+      expect(success).toBeTruthy()
+
+      const [group] = results
+
+      expect(group.path).toBe("GroupA/Child")
+      expect(group.results).toHaveLength(2)
+      expect(group.success).toBeTruthy()
+
+      const [t1, t2] = group.results
+      expect(t1.name).toBe("one")
+      expect(t2.name).toBe("two")
+    },
+    TIMEOUT,
+  )
+
+  it(
+    "deploy all",
+    async () => {
+      const { options, variables, watch } = await createOptions()
+
+      const {
+        results,
+        status,
+        success,
+      } = await deploymentTargetsOperationCommand(
+        {
+          operation: DeploymentOperation.DEPLOY,
+          targets: [],
+          groups: [],
+          configFile: "targets-3.yml",
+          options,
+          variables,
+          watch,
+        },
+        new CliUndeployTargetsIO(
+          options,
+          (options: Options, loggerName: string) =>
+            new TestDeployStacksIO(options),
+          (options: Options, loggerName: string) =>
+            new TestUndeployStacksIO(options),
+        ),
+      )
+
+      expect(status).toBe(CommandStatus.SUCCESS)
+      expect(results).toHaveLength(1)
+      expect(success).toBeTruthy()
+
+      const [group] = results
+
+      expect(group.path).toBe("GroupA/Child")
+      expect(group.results).toHaveLength(2)
+      expect(group.success).toBeTruthy()
+      expect(group.status).toBe(CommandStatus.SUCCESS)
+
+      const [t1, t2] = group.results
+      expect(t1.name).toBe("one")
+      expect(t2.name).toBe("two")
+    },
+    TIMEOUT,
+  )
+})

--- a/integration-tests/organization/configs/example/my-web/stacks/dev/web/example.yml
+++ b/integration-tests/organization/configs/example/my-web/stacks/dev/web/example.yml
@@ -1,0 +1,2 @@
+regions: eu-north-1
+template: example.yml

--- a/integration-tests/organization/configs/example/my-web/templates/example.yml
+++ b/integration-tests/organization/configs/example/my-web/templates/example.yml
@@ -1,0 +1,4 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties: {}

--- a/integration-tests/organization/configs/organization/organization.yml
+++ b/integration-tests/organization/configs/organization/organization.yml
@@ -16,4 +16,8 @@ configSets:
     description: Bootstrap
     commandPaths:
       - /bootstrap
-
+  example:
+    description: Using project dir
+    projectDir: example/my-web
+    commandPaths:
+      - /dev/web

--- a/integration-tests/organization/configs/organization/partials/v08.yml
+++ b/integration-tests/organization/configs/organization/partials/v08.yml
@@ -1,0 +1,37 @@
+#
+# Test config set with project dir ("example")
+#
+
+tagPolicies: true
+
+organizationalUnits:
+  Root:
+    accounts:
+      - id: "{{ env.TKM_ORG_A_MASTER_ACCOUNT_ID }}"
+        description: master
+        status: disabled
+  Root/test-accounts:
+    bootstrapConfigSets:
+      - bootstrap
+    configSets:
+      - basic
+    accounts:
+      - id: "{{ env.TKM_ORG_A_ACCOUNT_1_ID }}"
+        vars:
+          vpcCidr: 10.0.0.0/24
+          costCenter: aaa
+      - id: "{{ env.TKM_ORG_A_ACCOUNT_2_ID }}"
+        vars:
+          vpcCidr: 10.0.1.0/24
+          costCenter: bbb
+      - id: "{{ env.TKM_ORG_A_ACCOUNT_3_ID }}"
+        vars:
+          vpcCidr: 10.0.2.0/24
+          costCenter: ccc
+  "Root/sandbox accounts/sandbox-1": {}
+  "Root/sandbox accounts/sandbox-2":
+    configSets:
+      - example
+    accounts:
+      - "{{ env.TKM_ORG_A_ACCOUNT_4_ID }}"
+      - "{{ env.TKM_ORG_A_ACCOUNT_5_ID }}"

--- a/integration-tests/organization/test/organization.test.ts
+++ b/integration-tests/organization/test/organization.test.ts
@@ -346,4 +346,52 @@ describe("Organization commands", () => {
     },
     TIMEOUT,
   )
+
+  it(
+    "deploy organizational units that use config set with different project dir",
+    async () => {
+      const { options, watch, variables } = await createOptions("v08")
+      const {
+        success,
+        status,
+        message,
+        results,
+      } = await accountsOperationCommand(
+        {
+          variables,
+          watch,
+          options,
+          accountIds: [],
+          organizationalUnits: ["Root/sandbox accounts/sandbox-2"],
+          operation: DeploymentOperation.DEPLOY,
+          configSetType: ConfigSetType.STANDARD,
+        },
+        new CliDeployAccountsIO(
+          options,
+          (options: Options, accountId: string) =>
+            new CliDeployStacksIO(options, accountId),
+          (options: Options, accountId: string) =>
+            new CliUndeployStacksIO(options, accountId),
+        ),
+      )
+
+      expect(success).toBeTruthy()
+      expect(status).toBe(CommandStatus.SUCCESS)
+      expect(message).toBe("Success")
+
+      expect(results).toHaveLength(1)
+
+      const [sandbox2Ou] = results
+      expect(sandbox2Ou.results).toHaveLength(2)
+
+      const [a4, a5] = sandbox2Ou.results
+
+      expect(a4.accountId).toBe(ORG_A_ACCOUNT_4_ID)
+      expect(a4.success).toBeTruthy()
+
+      expect(a5.accountId).toBe(ORG_A_ACCOUNT_5_ID)
+      expect(a5.success).toBeTruthy()
+    },
+    TIMEOUT,
+  )
 })

--- a/packages/takomo-config-sets/src/config/parser.ts
+++ b/packages/takomo-config-sets/src/config/parser.ts
@@ -6,10 +6,11 @@ export const parseConfigSets = (value: any): ConfigSet[] => {
   }
 
   return Object.keys(value).map((name) => {
-    const { description, vars, commandPaths } = value[name]
+    const { description, vars, commandPaths, projectDir } = value[name]
     return {
       name,
       description,
+      projectDir: projectDir || null,
       vars: vars || {},
       commandPaths: commandPaths || [],
     }

--- a/packages/takomo-config-sets/src/config/schema.ts
+++ b/packages/takomo-config-sets/src/config/schema.ts
@@ -6,9 +6,12 @@ export const configSetName = Joi.string()
   .max(60)
   .regex(/^[a-zA-Z_]+[a-zA-Z0-9-_]*$/)
 
+export const projectDir = Joi.string()
+
 export const configSet = Joi.object({
   description: Joi.string(),
   commandPaths: Joi.array().items(commandPath).unique(),
+  projectDir,
   vars,
 })
 

--- a/packages/takomo-config-sets/src/fn.ts
+++ b/packages/takomo-config-sets/src/fn.ts
@@ -1,0 +1,31 @@
+import { Options } from "@takomo/core"
+import path from "path"
+import { ConfigSet } from "./model"
+
+export const buildOptionsForConfigSet = (
+  currentOptions: Options,
+  configSet: ConfigSet,
+): Options => {
+  const configSetProjectDir = configSet.projectDir
+
+  if (configSetProjectDir === null) {
+    return currentOptions
+  }
+
+  const props = currentOptions.toProps()
+
+  if (
+    configSetProjectDir.startsWith("/") ||
+    configSetProjectDir.startsWith("~")
+  ) {
+    return new Options({
+      ...props,
+      projectDir: configSetProjectDir,
+    })
+  }
+
+  return new Options({
+    ...props,
+    projectDir: path.join(currentOptions.getProjectDir(), configSetProjectDir),
+  })
+}

--- a/packages/takomo-config-sets/src/index.ts
+++ b/packages/takomo-config-sets/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./config"
+export * from "./fn"
 export * from "./model"

--- a/packages/takomo-config-sets/src/model.ts
+++ b/packages/takomo-config-sets/src/model.ts
@@ -9,6 +9,7 @@ export interface ConfigSet {
   readonly name: ConfigSetName
   readonly vars: Vars
   readonly commandPaths: CommandPath[]
+  readonly projectDir: string | null
 }
 
 export enum ConfigSetType {

--- a/packages/takomo-config-sets/test/build-options-for-config-set.test.ts
+++ b/packages/takomo-config-sets/test/build-options-for-config-set.test.ts
@@ -1,0 +1,67 @@
+import { Options } from "@takomo/core"
+import { LogLevel } from "@takomo/util"
+import { buildOptionsForConfigSet } from "../src/fn"
+
+const currentOptions = new Options({
+  projectDir: "/tmp",
+  stats: false,
+  logLevel: LogLevel.INFO,
+  logConfidentialInfo: false,
+  autoConfirm: false,
+})
+
+describe("#buildOptionsForConfigSet returns correct Options object", () => {
+  test("when the config set has no projectDir defined", () => {
+    const options = buildOptionsForConfigSet(currentOptions, {
+      commandPaths: ["/dev"],
+      description: "My config set",
+      name: "MyConfigSet",
+      projectDir: null,
+      vars: {},
+    })
+
+    expect(options.getProjectDir()).toBe(options.getProjectDir())
+    expect(options.isAutoConfirmEnabled()).toBe(options.isAutoConfirmEnabled())
+    expect(options.getLogLevel()).toBe(options.getLogLevel())
+    expect(options.isConfidentialInfoLoggingEnabled()).toBe(
+      options.isConfidentialInfoLoggingEnabled(),
+    )
+    expect(options.isStatsEnabled()).toBe(options.isStatsEnabled())
+  })
+
+  test("when the config set has absolute projectDir defined", () => {
+    const options = buildOptionsForConfigSet(currentOptions, {
+      commandPaths: ["/dev"],
+      description: "My config set",
+      name: "MyConfigSet",
+      projectDir: "/vars/configs",
+      vars: {},
+    })
+
+    expect(options.getProjectDir()).toBe("/vars/configs")
+    expect(options.isAutoConfirmEnabled()).toBe(options.isAutoConfirmEnabled())
+    expect(options.getLogLevel()).toBe(options.getLogLevel())
+    expect(options.isConfidentialInfoLoggingEnabled()).toBe(
+      options.isConfidentialInfoLoggingEnabled(),
+    )
+    expect(options.isStatsEnabled()).toBe(options.isStatsEnabled())
+  })
+
+  test("when the config set has relative projectDir defined", () => {
+    const options = buildOptionsForConfigSet(currentOptions, {
+      commandPaths: ["/dev"],
+      description: "My config set",
+      name: "MyConfigSet",
+      projectDir: "files",
+      vars: {},
+    })
+
+    expect(options.getProjectDir()).toBe("/tmp/files")
+    expect(options.isAutoConfirmEnabled()).toBe(options.isAutoConfirmEnabled())
+    expect(options.getLogLevel()).toBe(options.getLogLevel())
+    expect(options.isConfidentialInfoLoggingEnabled()).toBe(
+      options.isConfidentialInfoLoggingEnabled(),
+    )
+    expect(options.isStatsEnabled()).toBe(options.isStatsEnabled())
+  })
+})

--- a/packages/takomo-config-sets/test/config/schema/config-set-name.test.ts
+++ b/packages/takomo-config-sets/test/config/schema/config-set-name.test.ts
@@ -1,5 +1,5 @@
-import { configSetName } from "../src/"
-import { expectNoValidationError, expectValidationErrors } from "./helpers"
+import { configSetName } from "../../../src/"
+import { expectNoValidationError, expectValidationErrors } from "../../helpers"
 
 const valid = ["basic", "Example", "my-group", "_with_underscores"]
 

--- a/packages/takomo-config-sets/test/config/schema/config-set.test.ts
+++ b/packages/takomo-config-sets/test/config/schema/config-set.test.ts
@@ -1,0 +1,49 @@
+import { configSet } from "../../../src/config/schema"
+import { expectNoValidationError } from "../../helpers"
+
+describe("config set validation", () => {
+  describe("should succeed when", () => {
+    test("a valid minimum config set is given", () => {
+      expectNoValidationError(configSet)({
+        description: "my config set",
+        commandPaths: ["/path"],
+      })
+    })
+    test("a valid config set with vars is given", () => {
+      expectNoValidationError(configSet)({
+        description: "my config set",
+        commandPaths: ["/path"],
+        vars: {
+          hello: "world",
+          code: 123,
+          array: ["a", "b"],
+          obj: {
+            name: "zorro",
+          },
+        },
+      })
+    })
+    test("a valid config set with projectDir is given", () => {
+      expectNoValidationError(configSet)({
+        description: "my config set",
+        commandPaths: ["/path"],
+        projectDir: "/tmp",
+      })
+    })
+    test("a valid full config set is given", () => {
+      expectNoValidationError(configSet)({
+        description: "my config set",
+        commandPaths: ["/path", "/another"],
+        projectDir: "/tmp",
+        vars: {
+          hello: "world",
+          code: 123,
+          array: ["a", "b"],
+          obj: {
+            name: "zorro",
+          },
+        },
+      })
+    })
+  })
+})

--- a/packages/takomo-config-sets/test/config/schema/project-dir.test.ts
+++ b/packages/takomo-config-sets/test/config/schema/project-dir.test.ts
@@ -1,0 +1,28 @@
+import { projectDir } from "../../../src/config/schema"
+import { expectNoValidationError, expectValidationErrors } from "../../helpers"
+
+const valid = ["basic", "/tmp", "~/Docs"]
+
+describe("project dir validation", () => {
+  test.each(valid)(
+    "succeeds when '%s' is given",
+    expectNoValidationError(projectDir),
+  )
+
+  describe("fails when", () => {
+    test("an empty string is given", () => {
+      expectValidationErrors(projectDir)(
+        "",
+        '"value" is not allowed to be empty',
+      )
+    })
+
+    test("a number is given", () => {
+      expectValidationErrors(projectDir)(100, '"value" must be a string')
+    })
+
+    test("a boolean is given", () => {
+      expectValidationErrors(projectDir)(100, '"value" must be a string')
+    })
+  })
+})

--- a/packages/takomo-config-sets/test/helpers.ts
+++ b/packages/takomo-config-sets/test/helpers.ts
@@ -13,12 +13,13 @@ export const expectValidationErrors = (
   value: any,
   ...expectedMessages: string[]
 ) => {
-  const {
-    error: { details },
-  } = validator.validate(value, { abortEarly: false })
+  const { error } = validator.validate(value, { abortEarly: false })
+  if (error === undefined) {
+    fail("Expected error to be defined")
+  }
 
   const expected = expectedMessages.slice().sort().join("\n")
-  const actual = details
+  const actual = error.details
     .map((d) => d.message)
     .sort()
     .join("\n")

--- a/packages/takomo-core/src/model.ts
+++ b/packages/takomo-core/src/model.ts
@@ -140,19 +140,25 @@ export class Options {
   /**
    * @returns Should confidential information be logged in plain text
    */
-
   isConfidentialInfoLoggingEnabled = (): boolean => this.logConfidentialInfo
 
   /**
    * @returns Is auto-confirm enabled
    */
-
   isAutoConfirmEnabled = (): boolean => this.autoConfirm
 
   /**
    * @returns Should statistics be collected
    */
   isStatsEnabled = (): boolean => this.stats
+
+  toProps = (): OptionsProps => ({
+    projectDir: this.projectDir,
+    autoConfirm: this.autoConfirm,
+    logLevel: this.logLevel,
+    logConfidentialInfo: this.logConfidentialInfo,
+    stats: this.stats,
+  })
 }
 
 export interface OperationState {

--- a/packages/takomo-core/test/schema/vars.test.ts
+++ b/packages/takomo-core/test/schema/vars.test.ts
@@ -1,4 +1,5 @@
 import { vars } from "../../src/schema"
+import { expectValidationErrors } from "../helpers"
 
 describe("vars validation succeeds", () => {
   test("when an empty object is given", () => {
@@ -29,22 +30,18 @@ describe("vars validation succeeds", () => {
 
 describe("vars validation fails", () => {
   test("when an array is given", () => {
-    const { error } = vars.validate([])
-    expect(error.message).toBe('"value" must be of type object')
+    expectValidationErrors(vars)([], '"value" must be of type object')
   })
 
   test("when a string is given", () => {
-    const { error } = vars.validate("stringy")
-    expect(error.message).toBe('"value" must be of type object')
+    expectValidationErrors(vars)("stringy", '"value" must be of type object')
   })
 
   test("when a number is given", () => {
-    const { error } = vars.validate(100)
-    expect(error.message).toBe('"value" must be of type object')
+    expectValidationErrors(vars)(100, '"value" must be of type object')
   })
 
   test("when a boolean is given", () => {
-    const { error } = vars.validate(true)
-    expect(error.message).toBe('"value" must be of type object')
+    expectValidationErrors(vars)(true, '"value" must be of type object')
   })
 })

--- a/packages/takomo-deployment-targets/src/command/operation/process/command-path.ts
+++ b/packages/takomo-deployment-targets/src/command/operation/process/command-path.ts
@@ -124,6 +124,7 @@ export const processCommandPath = async (
   group: DeploymentGroupConfig,
   target: DeploymentTargetConfig,
   configSet: ConfigSet,
+  options: Options,
   commandPath: CommandPath,
   watch: StopWatch,
   state: OperationState,
@@ -136,7 +137,6 @@ export const processCommandPath = async (
 
   const configFile = ctx.getConfigFile()
   const variables = ctx.getVariables()
-  const options = ctx.getOptions()
 
   io.info(`Execute command path: ${commandPath}`)
 

--- a/packages/takomo-deployment-targets/src/command/operation/process/config-set.ts
+++ b/packages/takomo-deployment-targets/src/command/operation/process/config-set.ts
@@ -1,4 +1,5 @@
 import {
+  buildOptionsForConfigSet,
   ConfigSet,
   ConfigSetCommandPathOperationResult,
   ConfigSetOperationResult,
@@ -17,11 +18,12 @@ export const processConfigSet = async (
   watch: StopWatch,
   state: OperationState,
 ): Promise<ConfigSetOperationResult> => {
-  const { io } = holder
+  const { io, ctx } = holder
 
   io.info(`Execute config set: ${configSet.name}`)
 
   const results = new Array<ConfigSetCommandPathOperationResult>()
+  const options = buildOptionsForConfigSet(ctx.getOptions(), configSet)
 
   for (const commandPath of configSet.commandPaths) {
     const result = await processCommandPath(
@@ -29,6 +31,7 @@ export const processConfigSet = async (
       group,
       target,
       configSet,
+      options,
       commandPath,
       watch.startChild(commandPath),
       state,

--- a/packages/takomo-organization/src/command/accounts/operation/execute/command-path.ts
+++ b/packages/takomo-organization/src/command/accounts/operation/execute/command-path.ts
@@ -7,6 +7,7 @@ import {
   CommandStatus,
   DeploymentOperation,
   OperationState,
+  Options,
   TakomoCredentialProvider,
 } from "@takomo/core"
 import {
@@ -83,6 +84,7 @@ export const processCommandPath = async (
   ou: PlannedAccountDeploymentOrganizationalUnit,
   plannedAccount: PlannedLaunchableAccount,
   configSetName: string,
+  options: Options,
   commandPath: CommandPath,
   commandPathWatch: StopWatch,
   state: OperationState,
@@ -91,7 +93,7 @@ export const processCommandPath = async (
   const {
     io,
     ctx,
-    input: { variables, options, operation },
+    input: { variables, operation },
   } = holder
   const account = plannedAccount.config
   const credentialProvider = ctx.getCredentialProvider()

--- a/packages/takomo-organization/src/command/accounts/operation/execute/config-set.ts
+++ b/packages/takomo-organization/src/command/accounts/operation/execute/config-set.ts
@@ -1,4 +1,5 @@
 import {
+  buildOptionsForConfigSet,
   ConfigSetCommandPathOperationResult,
   ConfigSetName,
   ConfigSetOperationResult,
@@ -28,12 +29,15 @@ export const processConfigSet = async (
   const configSet = ctx.getConfigSet(configSetName)
   const results = new Array<ConfigSetCommandPathOperationResult>()
 
+  const options = buildOptionsForConfigSet(ctx.getOptions(), configSet)
+
   for (const commandPath of configSet.commandPaths) {
     const result = await processCommandPath(
       holder,
       ou,
       plannedAccount,
       configSetName,
+      options,
       commandPath,
       configSetWatch.startChild(commandPath),
       state,


### PR DESCRIPTION
affects: @takomo/config-sets, @takomo/core, @takomo/deployment-targets, @takomo/organization

ISSUES CLOSED: #24