### PR TITLE
feat: add accountId property to deployment targets

### DIFF
--- a/packages/takomo-cli-io/src/stacks/deploy-stacks-io.ts
+++ b/packages/takomo-cli-io/src/stacks/deploy-stacks-io.ts
@@ -457,7 +457,7 @@ export class CliDeployStacksIO extends CliIO implements DeployStacksIO {
     this.message(
       `add: ${green(addCount)}, update: ${yellow(
         modifyCount,
-      )}, replace: ${orange(replaceCount)}. delete: ${red(removeCount)}`,
+      )}, replace: ${orange(replaceCount)}, delete: ${red(removeCount)}`,
       true,
       true,
     )

--- a/packages/takomo-deployment-targets/src/config/parser.ts
+++ b/packages/takomo-deployment-targets/src/config/parser.ts
@@ -50,8 +50,9 @@ const parseDeploymentTarget = (
 
   return {
     configSets,
-    name: value.name,
-    description: value.description,
+    name: value.name || null,
+    description: value.description || null,
+    accountId: value.accountId || null,
     deploymentRole: parseCommandRole(value.deploymentRole),
     status: parseDeploymentStatus(value.status),
     vars: parseVars(value.vars),

--- a/packages/takomo-deployment-targets/src/model.ts
+++ b/packages/takomo-deployment-targets/src/model.ts
@@ -1,5 +1,6 @@
 import { ConfigSet, ConfigSetName } from "@takomo/config-sets"
 import {
+  AccountId,
   CommandRole,
   Options,
   TakomoCredentialProvider,
@@ -24,6 +25,7 @@ export interface DeploymentTargetConfig {
   readonly vars: Vars
   readonly configSets: ConfigSetName[]
   readonly deploymentRole: CommandRole | null
+  readonly accountId: AccountId | null
 }
 
 export interface DeploymentGroupConfig {

--- a/packages/takomo-deployment-targets/src/schema.ts
+++ b/packages/takomo-deployment-targets/src/schema.ts
@@ -1,6 +1,6 @@
 import Joi from "@hapi/joi"
 import { configSetName } from "@takomo/config-sets"
-import { iamRoleArn, vars } from "@takomo/core"
+import { accountId, iamRoleArn, vars } from "@takomo/core"
 
 export const deploymentGroupPath = Joi.string()
   .min(1)
@@ -48,6 +48,7 @@ export const deploymentTargetName = Joi.string()
 
 const deploymentTarget = Joi.object({
   vars,
+  accountId,
   name: deploymentTargetName.required(),
   deploymentRole: iamRoleArn,
   description: Joi.string(),


### PR DESCRIPTION
affects: @takomo/cli-io, @takomo/deployment-targets

ISSUES CLOSED: #58