### PR TITLE
feat: add CLI commands to bootstrap and tear down deployment targets

### DIFF
--- a/integration-tests/deployment-targets/configs/deployment/targets-4.yml
+++ b/integration-tests/deployment-targets/configs/deployment/targets-4.yml
@@ -1,0 +1,18 @@
+deploymentGroups:
+  Example:
+    targets:
+      - name: one
+        bootstrapRole: arn:aws:iam::{{ env.TKM_ORG_A_ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+        vars:
+          accountId: "{{ env.TKM_ORG_A_ACCOUNT_1_ID }}"
+      - name: two
+        bootstrapRole: arn:aws:iam::{{ env.TKM_ORG_A_ACCOUNT_2_ID }}:role/OrganizationAccountAccessRole
+        bootstrapConfigSets: logs2
+        vars:
+          accountId: "{{ env.TKM_ORG_A_ACCOUNT_2_ID }}"
+
+configSets:
+  logs2:
+    description: Logging configs 2
+    commandPaths:
+      - /logs-2.yml

--- a/integration-tests/deployment-targets/package.json
+++ b/integration-tests/deployment-targets/package.json
@@ -24,6 +24,7 @@
     "@takomo/cli-io": "2.3.0",
     "@takomo/core": "2.3.0",
     "@takomo/deployment-targets": "2.3.0",
+    "@takomo/config-sets": "2.3.0",
     "@takomo/test": "2.3.0"
   },
   "devDependencies": {

--- a/integration-tests/deployment-targets/test/bootstrap.test.ts
+++ b/integration-tests/deployment-targets/test/bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { initOptionsAndVariables } from "@takomo/cli"
-import { CliUndeployTargetsIO } from "@takomo/cli-io"
+import { CliBootstrapTargetsIO, CliTearDownTargetsIO } from "@takomo/cli-io"
 import { ConfigSetType } from "@takomo/config-sets"
 import { CommandStatus, DeploymentOperation, Options } from "@takomo/core"
 import { deploymentTargetsOperationCommand } from "@takomo/deployment-targets"
@@ -12,9 +12,9 @@ const createOptions = async () =>
     dir: "configs",
   })
 
-describe("Deployment with project dir", () => {
-  it(
-    "undeploy all",
+describe("Bootstrapping", () => {
+  test(
+    "tear down all",
     async () => {
       const { options, variables, watch } = await createOptions()
 
@@ -25,15 +25,15 @@ describe("Deployment with project dir", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.UNDEPLOY,
-          configSetType: ConfigSetType.STANDARD,
+          configSetType: ConfigSetType.BOOTSTRAP,
           targets: [],
           groups: [],
-          configFile: "targets-3.yml",
+          configFile: "targets-4.yml",
           options,
           variables,
           watch,
         },
-        new CliUndeployTargetsIO(
+        new CliTearDownTargetsIO(
           options,
           (options: Options, loggerName: string) =>
             new TestDeployStacksIO(options),
@@ -45,21 +45,21 @@ describe("Deployment with project dir", () => {
       expect(results).toHaveLength(1)
       expect(success).toBeTruthy()
 
-      const [group] = results
+      const [exampleGroup] = results
 
-      expect(group.path).toBe("GroupA/Child")
-      expect(group.results).toHaveLength(2)
-      expect(group.success).toBeTruthy()
+      expect(exampleGroup.path).toBe("Example")
+      expect(exampleGroup.results).toHaveLength(1)
+      expect(exampleGroup.success).toBeTruthy()
+      expect(exampleGroup.status).toBe(CommandStatus.SUCCESS)
 
-      const [t1, t2] = group.results
-      expect(t1.name).toBe("one")
-      expect(t2.name).toBe("two")
+      const [target] = exampleGroup.results
+      expect(target.name).toBe("two")
     },
     TIMEOUT,
   )
 
-  it(
-    "deploy all",
+  test(
+    "bootstrap all",
     async () => {
       const { options, variables, watch } = await createOptions()
 
@@ -70,15 +70,15 @@ describe("Deployment with project dir", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.DEPLOY,
-          configSetType: ConfigSetType.STANDARD,
+          configSetType: ConfigSetType.BOOTSTRAP,
           targets: [],
           groups: [],
-          configFile: "targets-3.yml",
+          configFile: "targets-4.yml",
           options,
           variables,
           watch,
         },
-        new CliUndeployTargetsIO(
+        new CliBootstrapTargetsIO(
           options,
           (options: Options, loggerName: string) =>
             new TestDeployStacksIO(options),
@@ -91,16 +91,15 @@ describe("Deployment with project dir", () => {
       expect(results).toHaveLength(1)
       expect(success).toBeTruthy()
 
-      const [group] = results
+      const [exampleGroup] = results
 
-      expect(group.path).toBe("GroupA/Child")
-      expect(group.results).toHaveLength(2)
-      expect(group.success).toBeTruthy()
-      expect(group.status).toBe(CommandStatus.SUCCESS)
+      expect(exampleGroup.path).toBe("Example")
+      expect(exampleGroup.results).toHaveLength(1)
+      expect(exampleGroup.success).toBeTruthy()
+      expect(exampleGroup.status).toBe(CommandStatus.SUCCESS)
 
-      const [t1, t2] = group.results
-      expect(t1.name).toBe("one")
-      expect(t2.name).toBe("two")
+      const [target] = exampleGroup.results
+      expect(target.name).toBe("two")
     },
     TIMEOUT,
   )

--- a/integration-tests/deployment-targets/test/deploy-with-deployment-role.test.ts
+++ b/integration-tests/deployment-targets/test/deploy-with-deployment-role.test.ts
@@ -1,5 +1,6 @@
 import { initOptionsAndVariables } from "@takomo/cli"
 import { CliUndeployTargetsIO } from "@takomo/cli-io"
+import { ConfigSetType } from "@takomo/config-sets"
 import { CommandStatus, DeploymentOperation, Options } from "@takomo/core"
 import { deploymentTargetsOperationCommand } from "@takomo/deployment-targets"
 import { TestDeployStacksIO, TestUndeployStacksIO, TIMEOUT } from "@takomo/test"
@@ -24,6 +25,7 @@ describe("Deployment with deployment role", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.UNDEPLOY,
+          configSetType: ConfigSetType.STANDARD,
           targets: [],
           groups: [],
           configFile: "targets-2.yml",
@@ -70,6 +72,7 @@ describe("Deployment with deployment role", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.DEPLOY,
+          configSetType: ConfigSetType.STANDARD,
           targets: [],
           groups: [],
           configFile: "targets-2.yml",

--- a/integration-tests/deployment-targets/test/deploy.test.ts
+++ b/integration-tests/deployment-targets/test/deploy.test.ts
@@ -1,5 +1,6 @@
 import { initOptionsAndVariables } from "@takomo/cli"
 import { CliUndeployTargetsIO } from "@takomo/cli-io"
+import { ConfigSetType } from "@takomo/config-sets"
 import { CommandStatus, DeploymentOperation, Options } from "@takomo/core"
 import { deploymentTargetsOperationCommand } from "@takomo/deployment-targets"
 import { TestDeployStacksIO, TestUndeployStacksIO, TIMEOUT } from "@takomo/test"
@@ -24,6 +25,7 @@ describe("Deployment group commands", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.UNDEPLOY,
+          configSetType: ConfigSetType.STANDARD,
           targets: [],
           groups: [],
           configFile: null,
@@ -80,6 +82,7 @@ describe("Deployment group commands", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.DEPLOY,
+          configSetType: ConfigSetType.STANDARD,
           targets: [],
           groups: ["Environments/Test"],
           configFile: null,
@@ -127,6 +130,7 @@ describe("Deployment group commands", () => {
       } = await deploymentTargetsOperationCommand(
         {
           operation: DeploymentOperation.DEPLOY,
+          configSetType: ConfigSetType.STANDARD,
           targets: ["two"],
           groups: [],
           configFile: null,

--- a/packages/takomo-cli-io/src/deployment-targets/bootstrap-targets-io.ts
+++ b/packages/takomo-cli-io/src/deployment-targets/bootstrap-targets-io.ts
@@ -1,0 +1,26 @@
+import { Options } from "@takomo/core"
+import { DeployStacksIO, UndeployStacksIO } from "@takomo/stacks-commands"
+import { CliDeploymentOperationIO } from "./deployment-operation-io"
+
+export class CliBootstrapTargetsIO extends CliDeploymentOperationIO {
+  constructor(
+    options: Options,
+    stacksDeployIO: (options: Options, loggerName: string) => DeployStacksIO,
+    stacksUndeployIO: (
+      options: Options,
+      loggerName: string,
+    ) => UndeployStacksIO,
+  ) {
+    super(
+      options,
+      {
+        confirmHeader: "Targets bootstrap plan",
+        confirmQuestion: "Continue to bootstrap targets?",
+        outputHeader: "Targets bootstrap summary",
+        outputNoTargets: "No targets bootstrapped",
+      },
+      stacksDeployIO,
+      stacksUndeployIO,
+    )
+  }
+}

--- a/packages/takomo-cli-io/src/deployment-targets/index.ts
+++ b/packages/takomo-cli-io/src/deployment-targets/index.ts
@@ -1,0 +1,4 @@
+export { CliBootstrapTargetsIO } from "./bootstrap-targets-io"
+export { CliDeployTargetsIO } from "./deploy-targets-io"
+export { CliTearDownTargetsIO } from "./tear-down-targets-io"
+export { CliUndeployTargetsIO } from "./undeploy-targets-io"

--- a/packages/takomo-cli-io/src/deployment-targets/tear-down-targets-io.ts
+++ b/packages/takomo-cli-io/src/deployment-targets/tear-down-targets-io.ts
@@ -1,0 +1,26 @@
+import { Options } from "@takomo/core"
+import { DeployStacksIO, UndeployStacksIO } from "@takomo/stacks-commands"
+import { CliDeploymentOperationIO } from "./deployment-operation-io"
+
+export class CliTearDownTargetsIO extends CliDeploymentOperationIO {
+  constructor(
+    options: Options,
+    stacksDeployIO: (options: Options, loggerName: string) => DeployStacksIO,
+    stacksUndeployIO: (
+      options: Options,
+      loggerName: string,
+    ) => UndeployStacksIO,
+  ) {
+    super(
+      options,
+      {
+        confirmHeader: "Targets tear down plan",
+        confirmQuestion: "Continue to tear down targets?",
+        outputHeader: "Targets tear down summary",
+        outputNoTargets: "No targets teared down",
+      },
+      stacksDeployIO,
+      stacksUndeployIO,
+    )
+  }
+}

--- a/packages/takomo-cli-io/src/index.ts
+++ b/packages/takomo-cli-io/src/index.ts
@@ -1,5 +1,4 @@
-export * from "./deployment-targets/deploy-targets-io"
-export * from "./deployment-targets/undeploy-targets-io"
+export * from "./deployment-targets"
 export { formatCommandStatus } from "./formatters"
 export * from "./init-project-io"
 export * from "./organization"

--- a/packages/takomo-cli/src/deployment-targets/bootstrap.ts
+++ b/packages/takomo-cli/src/deployment-targets/bootstrap.ts
@@ -1,6 +1,6 @@
 import {
+  CliBootstrapTargetsIO,
   CliDeployStacksIO,
-  CliDeployTargetsIO,
   CliUndeployStacksIO,
 } from "@takomo/cli-io"
 import { ConfigSetType } from "@takomo/config-sets"
@@ -19,14 +19,14 @@ const parseTargets = (value: any): string[] => {
   return Array.isArray(value) ? value : [value]
 }
 
-export const deployTargetsCmd = {
-  command: "deploy [groups..]",
-  desc: "Deploy deployment targets",
+export const bootstrapTargetsCmd = {
+  command: "bootstrap [groups..]",
+  desc: "Bootstrap deployment targets",
   builder: (yargs: any) =>
     yargs
       .epilog(commonEpilog(deployTargetsOperationCommandIamPolicy))
       .option("target", {
-        description: "Targets to deploy",
+        description: "Targets to bootstrap",
         string: true,
         global: false,
         demandOption: false,
@@ -46,12 +46,12 @@ export const deployTargetsCmd = {
         groups: argv.groups || [],
         configFile: argv["config-file"] || null,
         operation: DeploymentOperation.DEPLOY,
-        configSetType: ConfigSetType.STANDARD,
+        configSetType: ConfigSetType.BOOTSTRAP,
       }),
       (input) =>
         deploymentTargetsOperationCommand(
           input,
-          new CliDeployTargetsIO(
+          new CliBootstrapTargetsIO(
             input.options,
             (options: Options, loggerName: string) =>
               new CliDeployStacksIO(options, loggerName),

--- a/packages/takomo-cli/src/deployment-targets/index.ts
+++ b/packages/takomo-cli/src/deployment-targets/index.ts
@@ -1,11 +1,17 @@
+import { bootstrapTargetsCmd } from "./bootstrap"
 import { deployTargetsCmd } from "./deploy"
+import { tearDownTargetsCmd } from "./tear-down"
 import { undeployTargetsCmd } from "./undeploy"
 
 export const deploymentTargetsCmd = {
   command: "targets <command>",
   desc: "Deployment targets",
   builder: (yargs: any) =>
-    yargs.command(deployTargetsCmd).command(undeployTargetsCmd),
+    yargs
+      .command(deployTargetsCmd)
+      .command(undeployTargetsCmd)
+      .command(bootstrapTargetsCmd)
+      .command(tearDownTargetsCmd),
   // eslint-disable-next-line
   handler: (argv: any) => {},
 }

--- a/packages/takomo-cli/src/deployment-targets/tear-down.ts
+++ b/packages/takomo-cli/src/deployment-targets/tear-down.ts
@@ -1,13 +1,13 @@
 import {
   CliDeployStacksIO,
-  CliDeployTargetsIO,
+  CliTearDownTargetsIO,
   CliUndeployStacksIO,
 } from "@takomo/cli-io"
 import { ConfigSetType } from "@takomo/config-sets"
 import { DeploymentOperation, Options } from "@takomo/core"
 import {
   deploymentTargetsOperationCommand,
-  deployTargetsOperationCommandIamPolicy,
+  undeployTargetsOperationCommandIamPolicy,
 } from "@takomo/deployment-targets"
 import { commonEpilog, handle } from "../common"
 
@@ -19,14 +19,14 @@ const parseTargets = (value: any): string[] => {
   return Array.isArray(value) ? value : [value]
 }
 
-export const deployTargetsCmd = {
-  command: "deploy [groups..]",
-  desc: "Deploy deployment targets",
+export const tearDownTargetsCmd = {
+  command: "tear-down [groups..]",
+  desc: "Tear down deployment targets",
   builder: (yargs: any) =>
     yargs
-      .epilog(commonEpilog(deployTargetsOperationCommandIamPolicy))
+      .epilog(commonEpilog(undeployTargetsOperationCommandIamPolicy))
       .option("target", {
-        description: "Targets to deploy",
+        description: "Targets to tear down",
         string: true,
         global: false,
         demandOption: false,
@@ -45,13 +45,13 @@ export const deployTargetsCmd = {
         targets: parseTargets(argv.target),
         groups: argv.groups || [],
         configFile: argv["config-file"] || null,
-        operation: DeploymentOperation.DEPLOY,
-        configSetType: ConfigSetType.STANDARD,
+        operation: DeploymentOperation.UNDEPLOY,
+        configSetType: ConfigSetType.BOOTSTRAP,
       }),
       (input) =>
         deploymentTargetsOperationCommand(
           input,
-          new CliDeployTargetsIO(
+          new CliTearDownTargetsIO(
             input.options,
             (options: Options, loggerName: string) =>
               new CliDeployStacksIO(options, loggerName),

--- a/packages/takomo-cli/src/deployment-targets/undeploy.ts
+++ b/packages/takomo-cli/src/deployment-targets/undeploy.ts
@@ -3,6 +3,7 @@ import {
   CliUndeployStacksIO,
   CliUndeployTargetsIO,
 } from "@takomo/cli-io"
+import { ConfigSetType } from "@takomo/config-sets"
 import { DeploymentOperation, Options } from "@takomo/core"
 import {
   deploymentTargetsOperationCommand,
@@ -45,6 +46,7 @@ export const undeployTargetsCmd = {
         groups: argv.groups || [],
         configFile: argv["config-file"] || null,
         operation: DeploymentOperation.UNDEPLOY,
+        configSetType: ConfigSetType.STANDARD,
       }),
       (input) =>
         deploymentTargetsOperationCommand(

--- a/packages/takomo-deployment-targets/src/command/operation/model.ts
+++ b/packages/takomo-deployment-targets/src/command/operation/model.ts
@@ -1,4 +1,4 @@
-import { ConfigSetOperationResult } from "@takomo/config-sets"
+import { ConfigSetOperationResult, ConfigSetType } from "@takomo/config-sets"
 import {
   CommandInput,
   CommandOutput,
@@ -21,6 +21,7 @@ export interface DeploymentTargetsOperationInput extends CommandInput {
   readonly targets: string[]
   readonly configFile: string | null
   readonly operation: DeploymentOperation
+  readonly configSetType: ConfigSetType
 }
 
 export interface DeploymentTargetsOperationOutput extends CommandOutput {

--- a/packages/takomo-deployment-targets/src/command/operation/process/deployment-target.ts
+++ b/packages/takomo-deployment-targets/src/command/operation/process/deployment-target.ts
@@ -1,9 +1,28 @@
-import { ConfigSetOperationResult } from "@takomo/config-sets"
+import {
+  ConfigSetName,
+  ConfigSetOperationResult,
+  ConfigSetType,
+} from "@takomo/config-sets"
 import { OperationState, resolveCommandOutputBase } from "@takomo/core"
 import { StopWatch } from "@takomo/util"
 import { DeploymentGroupConfig, DeploymentTargetConfig } from "../../../model"
 import { DeploymentTargetDeployResult, PlanHolder } from "../model"
 import { processConfigSet } from "./config-set"
+
+const getConfigSetsToProcess = (
+  configSetType: ConfigSetType,
+  target: DeploymentTargetConfig,
+): ConfigSetName[] => {
+  switch (configSetType) {
+    case ConfigSetType.BOOTSTRAP:
+      return target.bootstrapConfigSets
+    case ConfigSetType.STANDARD:
+      return target.configSets
+    default:
+      throw new Error(`Unsupported config set type: ${configSetType}`)
+  }
+}
+
 export const processDeploymentTarget = async (
   holder: PlanHolder,
   group: DeploymentGroupConfig,
@@ -11,12 +30,14 @@ export const processDeploymentTarget = async (
   watch: StopWatch,
   state: OperationState,
 ): Promise<DeploymentTargetDeployResult> => {
-  const { io, ctx } = holder
+  const { io, ctx, input } = holder
 
   io.info(`Execute deployment target: ${target.name}`)
   const results = new Array<ConfigSetOperationResult>()
 
-  for (const configSetName of target.configSets) {
+  const configSetNames = getConfigSetsToProcess(input.configSetType, target)
+
+  for (const configSetName of configSetNames) {
     const configSet = ctx.getConfigSet(configSetName)
     const result = await processConfigSet(
       holder,

--- a/packages/takomo-deployment-targets/src/model.ts
+++ b/packages/takomo-deployment-targets/src/model.ts
@@ -24,7 +24,9 @@ export interface DeploymentTargetConfig {
   readonly description: string
   readonly vars: Vars
   readonly configSets: ConfigSetName[]
+  readonly bootstrapConfigSets: ConfigSetName[]
   readonly deploymentRole: CommandRole | null
+  readonly bootstrapRole: CommandRole | null
   readonly accountId: AccountId | null
 }
 
@@ -37,8 +39,10 @@ export interface DeploymentGroupConfig {
   readonly status: DeploymentStatus
   readonly vars: Vars
   readonly configSets: ConfigSetName[]
+  readonly bootstrapConfigSets: ConfigSetName[]
   readonly children: DeploymentGroupConfig[]
   readonly deploymentRole: CommandRole | null
+  readonly bootstrapRole: CommandRole | null
 }
 
 export interface DeploymentConfigFile {

--- a/packages/takomo-deployment-targets/src/schema.ts
+++ b/packages/takomo-deployment-targets/src/schema.ts
@@ -51,9 +51,14 @@ const deploymentTarget = Joi.object({
   accountId,
   name: deploymentTargetName.required(),
   deploymentRole: iamRoleArn,
+  bootstrapRole: iamRoleArn,
   description: Joi.string(),
   status: Joi.string().valid("active", "disabled"),
   configSets: [Joi.array().items(configSetName).unique(), configSetName],
+  bootstrapConfigSets: [
+    Joi.array().items(configSetName).unique(),
+    configSetName,
+  ],
 })
 
 const targets = Joi.array().items(deploymentTarget)
@@ -63,9 +68,14 @@ const deploymentGroup = Joi.object({
   targets,
   description: Joi.string(),
   deploymentRole: iamRoleArn,
+  bootstrapRole: iamRoleArn,
   status: Joi.string().valid("active", "disabled"),
   priority: Joi.number().integer().min(0),
   configSets: [Joi.array().items(configSetName).unique(), configSetName],
+  bootstrapConfigSets: [
+    Joi.array().items(configSetName).unique(),
+    configSetName,
+  ],
 })
 
 export const deploymentGroups = Joi.object()

--- a/packages/takomo-organization/src/command/accounts/operation/execute/command-path.ts
+++ b/packages/takomo-organization/src/command/accounts/operation/execute/command-path.ts
@@ -38,14 +38,12 @@ const executeOperation = async (
       return deployStacksCommand(
         input,
         io.createStackDeployIO(input.options, account.id),
-        //new CliDeployStacksIO(input.options, account.id),
         credentialProvider,
       )
     case DeploymentOperation.UNDEPLOY:
       return undeployStacksCommand(
         input,
         io.createStackUndeployIO(input.options, account.id),
-        //new CliUndeployStacksIO(input.options, account.id),
         credentialProvider,
       )
     default:


### PR DESCRIPTION
affects: integration-test-deployment-targets, @takomo/cli-io, @takomo/cli,
@takomo/deployment-targets, @takomo/organization

ISSUES CLOSED: #63