### PR TITLE
fix: fix handling of failed change set creation

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2-beta
         with:
-          version: 14.4.0
+          node-version: 14.4.0
       - uses: actions/cache@v1
         with:
           path: node_modules

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2-beta
         with:
-          version: 14.4.0
+          node-version: 14.4.0
       - uses: actions/cache@v1
         with:
           path: node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v2-beta
         with:
-          version: 14.4.0
+          node-version: 14.4.0
           registry-url: https://registry.npmjs.org
       - uses: actions/cache@v1
         with:

--- a/integration-tests/stacks/configs/stack-creation-with-review-fails/stacks/stack.yml
+++ b/integration-tests/stacks/configs/stack-creation-with-review-fails/stacks/stack.yml
@@ -1,0 +1,3 @@
+regions: eu-west-1
+name: stack-creation-with-review-fails
+template: {{ var.template }}

--- a/integration-tests/stacks/configs/stack-creation-with-review-fails/templates/template-with-error.yml
+++ b/integration-tests/stacks/configs/stack-creation-with-review-fails/templates/template-with-error.yml
@@ -1,0 +1,6 @@
+Conditions:
+  IncludeGlobalResources: !Equals [!Ref AWS::Region, eu-west-1]
+
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/configs/stack-creation-with-review-fails/templates/template.yml
+++ b/integration-tests/stacks/configs/stack-creation-with-review-fails/templates/template.yml
@@ -1,0 +1,3 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/test/stack-creation-with-review-fails.test.ts
+++ b/integration-tests/stacks/test/stack-creation-with-review-fails.test.ts
@@ -1,0 +1,152 @@
+import { initOptionsAndVariables } from "@takomo/cli"
+import { CommandStatus, Constants } from "@takomo/core"
+import {
+  ConfirmDeployAnswer,
+  ConfirmStackDeployAnswer,
+  deployStacksCommand,
+  undeployStacksCommand,
+} from "@takomo/stacks-commands"
+import { TestDeployStacksIO, TestUndeployStacksIO, TIMEOUT } from "@takomo/test"
+
+const createOptions = async (yes: boolean, template: string) =>
+  initOptionsAndVariables({
+    yes,
+    log: "info",
+    dir: "configs/stack-creation-with-review-fails",
+    var: `template=${template}`,
+  })
+
+// First, make sure that there are no existing stacks left from previous test runs
+beforeAll(async () => {
+  const { options, variables, watch } = await createOptions(
+    true,
+    "template.yml",
+  )
+  return await undeployStacksCommand(
+    {
+      commandPath: Constants.ROOT_STACK_GROUP_PATH,
+      ignoreDependencies: false,
+      interactive: false,
+      options,
+      variables,
+      watch,
+    },
+    new TestUndeployStacksIO(options),
+  )
+}, TIMEOUT)
+
+describe("Stack creation with review fails", () => {
+  test(
+    "Deploy with review should fail",
+    async () => {
+      const { options, variables, watch } = await createOptions(
+        false,
+        "template-with-error.yml",
+      )
+      const output = await deployStacksCommand(
+        {
+          commandPath: Constants.ROOT_STACK_GROUP_PATH,
+          options,
+          variables,
+          ignoreDependencies: false,
+          interactive: false,
+          watch,
+        },
+        new TestDeployStacksIO(options, {
+          confirmDeploy: ConfirmDeployAnswer.CONTINUE_AND_REVIEW,
+          confirmStackDeploy:
+            ConfirmStackDeployAnswer.CONTINUE_AND_SKIP_REMAINING_REVIEWS,
+        }),
+      )
+
+      expect(output.status).toBe(CommandStatus.FAILED)
+      expect(output.results[0].success).toBeFalsy()
+      expect(output.results[0].message).toBe(
+        "Template format error: YAML not well-formed. (line 2, column 44)",
+      )
+      expect(output.results[0].status).toBe(CommandStatus.FAILED)
+      expect(output.results[0].reason).toBe("CREATE_CHANGE_SET_FAILED")
+    },
+    TIMEOUT,
+  )
+
+  test(
+    "Deploy without review should fail",
+    async () => {
+      const { options, variables, watch } = await createOptions(
+        true,
+        "template-with-error.yml",
+      )
+      const output = await deployStacksCommand(
+        {
+          commandPath: Constants.ROOT_STACK_GROUP_PATH,
+          options,
+          variables,
+          ignoreDependencies: false,
+          interactive: false,
+          watch,
+        },
+        new TestDeployStacksIO(options),
+      )
+
+      expect(output.status).toBe(CommandStatus.FAILED)
+      expect(output.results[0].success).toBeFalsy()
+      expect(output.results[0].message).toBe("Failure")
+      expect(output.results[0].status).toBe(CommandStatus.FAILED)
+      expect(output.results[0].reason).toBe("CREATE_FAILED")
+    },
+    TIMEOUT,
+  )
+
+  test(
+    "Deploy with valid template should succeed",
+    async () => {
+      const { options, variables, watch } = await createOptions(
+        true,
+        "template.yml",
+      )
+      const output = await deployStacksCommand(
+        {
+          commandPath: Constants.ROOT_STACK_GROUP_PATH,
+          options,
+          variables,
+          ignoreDependencies: false,
+          interactive: false,
+          watch,
+        },
+        new TestDeployStacksIO(options),
+      )
+
+      expect(output.status).toBe(CommandStatus.SUCCESS)
+      expect(output.results[0].success).toBeTruthy()
+      expect(output.results[0].message).toBe("Success")
+      expect(output.results[0].status).toBe(CommandStatus.SUCCESS)
+      expect(output.results[0].reason).toBe("CREATE_SUCCESS")
+    },
+    TIMEOUT,
+  )
+
+  test(
+    "Undeploy",
+    async () => {
+      const { options, variables, watch } = await createOptions(
+        true,
+        "template.yml",
+      )
+      const output = await undeployStacksCommand(
+        {
+          commandPath: Constants.ROOT_STACK_GROUP_PATH,
+          ignoreDependencies: false,
+          interactive: false,
+          options,
+          variables,
+          watch,
+        },
+        new TestUndeployStacksIO(options),
+      )
+
+      expect(output.status).toBe(CommandStatus.SUCCESS)
+    },
+    TIMEOUT,
+  )
+})

--- a/packages/cli-io/src/stacks/deploy-stacks-io.ts
+++ b/packages/cli-io/src/stacks/deploy-stacks-io.ts
@@ -352,7 +352,7 @@ export class CliDeployStacksIO extends CliIO implements DeployStacksIO {
       `  ${yellow("~ update")}           Stack will be updated`,
       `  ${orange(
         "± replace",
-      )}          Stack is in invalid state and will be first deleted and then created`,
+      )}          Stack has an invalid status and will be first deleted and then created`,
       "",
       `Following ${stacks.length} stack(s) will be deployed:`,
     ])

--- a/packages/stacks-commands/src/stacks/deploy/execute-deploy-context.ts
+++ b/packages/stacks-commands/src/stacks/deploy/execute-deploy-context.ts
@@ -6,7 +6,7 @@ import {
 import { CommandContext, Stack, StackResult } from "@takomo/stacks-model"
 import { StopWatch } from "@takomo/util"
 import { StacksOperationInput, StacksOperationOutput } from "../../model"
-import { cleanFailedStacks } from "./clean-failed-stacks"
+import { cleanStacksWithInvalidStatus } from "./clean-stacks-with-invalid-status"
 import { IncompatibleIgnoreDependenciesOptionOnLaunchError } from "./errors"
 import { deployStack } from "./launch"
 import { ConfirmDeployAnswer, DeployStacksIO, DeployState } from "./model"
@@ -82,7 +82,7 @@ export const executeDeployContext = async (
     state.autoConfirm = true
   }
 
-  await cleanFailedStacks(ctx, io)
+  await cleanStacksWithInvalidStatus(ctx, io)
 
   if (state.autoConfirm) {
     return executeStacksInParallel(

--- a/packages/stacks-commands/src/stacks/deploy/review.ts
+++ b/packages/stacks-commands/src/stacks/deploy/review.ts
@@ -201,7 +201,7 @@ export const reviewChanges = async (
     logger.error("Failed to create change set", e)
     return {
       stack,
-      message: "Create change set failed",
+      message: e.message,
       reason: "CREATE_CHANGE_SET_FAILED",
       status: CommandStatus.FAILED,
       events: [],

--- a/packages/stacks-context/src/common.ts
+++ b/packages/stacks-context/src/common.ts
@@ -20,9 +20,8 @@ export const resolveStackLaunchType = (
       return StackLaunchType.UPDATE
     case "CREATE_FAILED":
     case "ROLLBACK_COMPLETE":
-      return StackLaunchType.RECREATE
     case "REVIEW_IN_PROGRESS":
-      return StackLaunchType.CREATE
+      return StackLaunchType.RECREATE
     default:
       throw new Error(`Unsupported stack status: ${status}`)
   }

--- a/packages/stacks-context/test/helpers.ts
+++ b/packages/stacks-context/test/helpers.ts
@@ -32,6 +32,7 @@ export const createStackGroup = (props: TestStackGroupProps): StackGroup =>
     data: {},
     capabilities: [],
     ignore: false,
+    terminationProtection: false,
   })
 
 export interface TestStackProps {
@@ -71,6 +72,7 @@ export const createStack = (props: TestStackProps): Stack => {
     },
     capabilities: [],
     ignore: false,
+    terminationProtection: false,
   })
 }
 
@@ -107,4 +109,5 @@ export const createStackConfig = (
     },
     capabilities: null,
     ignore: false,
+    terminationProtection: false,
   })

--- a/packages/stacks-context/test/resolve-stack-launch-type.test.ts
+++ b/packages/stacks-context/test/resolve-stack-launch-type.test.ts
@@ -1,15 +1,6 @@
 import { StackLaunchType } from "@takomo/stacks-model"
 import { resolveStackLaunchType } from "../src"
 
-const supported: Array<[string, StackLaunchType]> = [
-  ["CREATE_FAILED", StackLaunchType.RECREATE],
-  ["CREATE_COMPLETE", StackLaunchType.UPDATE],
-  ["ROLLBACK_COMPLETE", StackLaunchType.RECREATE],
-  ["UPDATE_COMPLETE", StackLaunchType.UPDATE],
-  ["UPDATE_ROLLBACK_COMPLETE", StackLaunchType.UPDATE],
-  ["REVIEW_IN_PROGRESS", StackLaunchType.CREATE],
-]
-
 const notSupported: Array<string> = [
   "CREATE_IN_PROGRESS",
   "ROLLBACK_IN_PROGRESS",
@@ -24,18 +15,48 @@ const notSupported: Array<string> = [
   "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
 ]
 
-describe("resolve stack launch type", () => {
-  describe.each(supported)("when %s is given", (status, expected) => {
-    test(`returns ${expected}`, () => {
-      expect(resolveStackLaunchType(status)).toBe(expected)
-    })
-  })
-
+describe("#resolveStackLaunchType", () => {
   describe.each(notSupported)("when %s is given", (status) => {
     test("throws an error", () => {
       expect(() => resolveStackLaunchType(status)).toThrow(
         `Unsupported stack status: ${status}`,
       )
     })
+  })
+
+  test("when CREATE_FAILED is given returns RECREATE", () => {
+    expect(resolveStackLaunchType("CREATE_FAILED")).toBe(
+      StackLaunchType.RECREATE,
+    )
+  })
+
+  test("when CREATE_COMPLETE is given returns UPDATE", () => {
+    expect(resolveStackLaunchType("CREATE_COMPLETE")).toBe(
+      StackLaunchType.UPDATE,
+    )
+  })
+
+  test("when ROLLBACK_COMPLETE is given returns RECREATE", () => {
+    expect(resolveStackLaunchType("ROLLBACK_COMPLETE")).toBe(
+      StackLaunchType.RECREATE,
+    )
+  })
+
+  test("when UPDATE_COMPLETE is given returns UPDATE", () => {
+    expect(resolveStackLaunchType("UPDATE_COMPLETE")).toBe(
+      StackLaunchType.UPDATE,
+    )
+  })
+
+  test("when UPDATE_ROLLBACK_COMPLETE is given returns UPDATE", () => {
+    expect(resolveStackLaunchType("UPDATE_ROLLBACK_COMPLETE")).toBe(
+      StackLaunchType.UPDATE,
+    )
+  })
+
+  test("when REVIEW_IN_PROGRESS is given returns RECREATE", () => {
+    expect(resolveStackLaunchType("REVIEW_IN_PROGRESS")).toBe(
+      StackLaunchType.RECREATE,
+    )
   })
 })

--- a/packages/test/src/io.ts
+++ b/packages/test/src/io.ts
@@ -13,31 +13,49 @@ import {
 } from "@takomo/stacks-commands"
 import { Secret, SecretName, SecretValue } from "@takomo/stacks-model"
 
+interface TestDeployStacksIOAnswers {
+  confirmDeploy: ConfirmDeployAnswer
+  confirmStackDeploy: ConfirmStackDeployAnswer
+}
+
 export class TestDeployStacksIO extends CliDeployStacksIO {
-  constructor(options: Options) {
+  readonly #answers: TestDeployStacksIOAnswers
+  constructor(options: Options, answers?: TestDeployStacksIOAnswers) {
     super(options)
+    this.#answers = answers || {
+      confirmDeploy: ConfirmDeployAnswer.CANCEL,
+      confirmStackDeploy: ConfirmStackDeployAnswer.CANCEL,
+    }
   }
 
   confirmDeploy = async (): Promise<ConfirmDeployAnswer> =>
     this.options.isAutoConfirmEnabled()
       ? ConfirmDeployAnswer.CONTINUE_NO_REVIEW
-      : ConfirmDeployAnswer.CANCEL
+      : this.#answers.confirmDeploy
 
   confirmStackDeploy = async (): Promise<ConfirmStackDeployAnswer> =>
     this.options.isAutoConfirmEnabled()
       ? ConfirmStackDeployAnswer.CONTINUE
-      : ConfirmStackDeployAnswer.CANCEL
+      : this.#answers.confirmStackDeploy
+}
+
+interface TestUndeployStacksIOAnswers {
+  confirmUndeploy: ConfirmUndeployAnswer
 }
 
 export class TestUndeployStacksIO extends CliUndeployStacksIO {
-  constructor(options: Options) {
+  readonly #answers: TestUndeployStacksIOAnswers
+  constructor(options: Options, answers?: TestUndeployStacksIOAnswers) {
     super(options)
+    this.#answers = answers || {
+      confirmUndeploy: ConfirmUndeployAnswer.CANCEL,
+    }
   }
 
   confirmUndeploy = async (): Promise<ConfirmUndeployAnswer> =>
     this.options.isAutoConfirmEnabled()
       ? ConfirmUndeployAnswer.CONTINUE
-      : ConfirmUndeployAnswer.CANCEL
+      : this.#answers.confirmUndeploy
 }
 
 export class TestListSecretsIO extends CliListSecretsIO {}


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/aws-clients, @takomo/cli-io, @takomo/stacks-commands,
@takomo/stacks-context, @takomo/test

Previously when change set creation failed it was incorrectly interpreted
to mean that the change set had no changes. Add logic to find out why
the change set creation failed.

ISSUES CLOSED: #96