### PR TITLE
fix: add NetworkingError to the list of retryable errors

### DIFF
--- a/packages/aws-clients/src/aws-client.ts
+++ b/packages/aws-clients/src/aws-client.ts
@@ -21,6 +21,7 @@ const retryableErrorCodes = [
   "UnknownEndpoint",
   "Throttling",
   "TooManyRequestsException",
+  "NetworkingError",
 ]
 
 export abstract class AwsClient<C> {


### PR DESCRIPTION
affects: @takomo/aws-clients

ISSUES CLOSED: #121