### PR TITLE
fix: fix a bug in undeploy stacks command

### DIFF
--- a/integration-tests/stacks/configs/undeploy/stacks/bar.yml
+++ b/integration-tests/stacks/configs/undeploy/stacks/bar.yml
@@ -1,0 +1,6 @@
+template: template.yml
+parameters:
+  Code:
+    resolver: stack-output
+    stack: foo.yml
+    output: Code

--- a/integration-tests/stacks/configs/undeploy/stacks/baz.yml
+++ b/integration-tests/stacks/configs/undeploy/stacks/baz.yml
@@ -1,0 +1,6 @@
+template: template.yml
+parameters:
+  Code:
+    resolver: stack-output
+    stack: /bar.yml
+    output: Code

--- a/integration-tests/stacks/configs/undeploy/stacks/config.yml
+++ b/integration-tests/stacks/configs/undeploy/stacks/config.yml
@@ -1,0 +1,2 @@
+regions: eu-west-1
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole

--- a/integration-tests/stacks/configs/undeploy/stacks/foo.yml
+++ b/integration-tests/stacks/configs/undeploy/stacks/foo.yml
@@ -1,0 +1,3 @@
+template: template.yml
+parameters:
+  Code: Foo

--- a/integration-tests/stacks/configs/undeploy/stacks/others/one.yml
+++ b/integration-tests/stacks/configs/undeploy/stacks/others/one.yml
@@ -1,0 +1,1 @@
+template: template2.yml

--- a/integration-tests/stacks/configs/undeploy/stacks/others/two.yml
+++ b/integration-tests/stacks/configs/undeploy/stacks/others/two.yml
@@ -1,0 +1,2 @@
+template: template2.yml
+depends: one.yml

--- a/integration-tests/stacks/configs/undeploy/templates/template.yml
+++ b/integration-tests/stacks/configs/undeploy/templates/template.yml
@@ -1,0 +1,12 @@
+Parameters:
+  Code:
+    Type: String
+    Description: Code
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+Outputs:
+  Code:
+    Description: Code output
+    Value: !Ref Code
+

--- a/integration-tests/stacks/configs/undeploy/templates/template2.yml
+++ b/integration-tests/stacks/configs/undeploy/templates/template2.yml
@@ -1,0 +1,4 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+

--- a/integration-tests/stacks/test/resolvers/external-stack-output.test.ts
+++ b/integration-tests/stacks/test/resolvers/external-stack-output.test.ts
@@ -8,39 +8,31 @@ import {
 } from "@takomo/test-integration"
 
 const projectDir = "configs/resolvers/external-stack-output"
+const stacks = [
+  {
+    stackName: "account-a-stack1",
+    stackPath: "/account-a/stack1.yml/us-east-1",
+  },
+  {
+    stackName: "account-a-stack2",
+    stackPath: "/account-a/stack2.yml/eu-west-1",
+  },
+  {
+    stackName: "account-b-stack3",
+    stackPath: "/account-b/stack3.yml/us-east-1",
+  },
+]
 
 describe("External stack output resolver", () => {
   test("Deploy", () =>
     executeDeployStacksCommand({ projectDir })
       .expectCommandToSucceed()
-      .expectStackCreateSuccess({
-        stackName: "account-a-stack1",
-        stackPath: "/account-a/stack1.yml/us-east-1",
-      })
-      .expectStackCreateSuccess({
-        stackName: "account-a-stack2",
-        stackPath: "/account-a/stack2.yml/eu-west-1",
-      })
-      .expectStackCreateSuccess({
-        stackName: "account-b-stack3",
-        stackPath: "/account-b/stack3.yml/us-east-1",
-      })
+      .expectStackCreateSuccess(...stacks)
       .assert())
 
   test("Undeploy", () =>
     executeUndeployStacksCommand({ projectDir })
       .expectCommandToSucceed()
-      .expectStackDeleteSuccess({
-        stackName: "account-a-stack1",
-        stackPath: "/account-a/stack1.yml/us-east-1",
-      })
-      .expectStackDeleteSuccess({
-        stackName: "account-a-stack2",
-        stackPath: "/account-a/stack2.yml/eu-west-1",
-      })
-      .expectStackDeleteSuccess({
-        stackName: "account-b-stack3",
-        stackPath: "/account-b/stack3.yml/us-east-1",
-      })
+      .expectStackDeleteSuccess(...stacks)
       .assert())
 })

--- a/integration-tests/stacks/test/undeploy.test.ts
+++ b/integration-tests/stacks/test/undeploy.test.ts
@@ -1,0 +1,86 @@
+import {
+  executeDeployStacksCommand,
+  executeUndeployStacksCommand,
+} from "@takomo/test-integration"
+
+const projectDir = "configs/undeploy"
+const stacks = [
+  {
+    stackPath: "/foo.yml/eu-west-1",
+    stackName: "foo",
+  },
+  {
+    stackPath: "/bar.yml/eu-west-1",
+    stackName: "bar",
+  },
+  {
+    stackPath: "/baz.yml/eu-west-1",
+    stackName: "baz",
+  },
+  {
+    stackPath: "/others/one.yml/eu-west-1",
+    stackName: "others-one",
+  },
+  {
+    stackPath: "/others/two.yml/eu-west-1",
+    stackName: "others-two",
+  },
+]
+
+describe("Undeploy", () => {
+  test("Deploy", () =>
+    executeDeployStacksCommand({
+      projectDir,
+    })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess(...stacks)
+      .assert())
+
+  test("Undeploy '/baz.yml' should not undeploy other stacks", () =>
+    executeUndeployStacksCommand({
+      projectDir,
+      commandPath: "/baz.yml",
+    })
+      .expectCommandToSucceed()
+      .expectStackDeleteSuccess({
+        stackPath: "/baz.yml/eu-west-1",
+        stackName: "baz",
+      })
+      .assert())
+
+  test("Undeploy '/foo.yml' should also undeploy '/bar.yml'", () =>
+    executeUndeployStacksCommand({
+      projectDir,
+      commandPath: "/foo.yml",
+    })
+      .expectCommandToSucceed()
+      .expectStackDeleteSuccess(
+        {
+          stackPath: "/foo.yml/eu-west-1",
+          stackName: "foo",
+        },
+        {
+          stackPath: "/bar.yml/eu-west-1",
+          stackName: "bar",
+        },
+      )
+      .expectSkippedStackResult({
+        message: "Stack not found",
+        stackPath: "/baz.yml/eu-west-1",
+        stackName: "baz",
+      })
+      .assert())
+
+  test("Undeploy '/others/one.yml' with ignore dependencies should not undeploy /others/two.yml", () =>
+    executeUndeployStacksCommand({
+      projectDir,
+      commandPath: "/others/one.yml",
+      ignoreDependencies: true,
+    })
+      .expectCommandToSucceed()
+      .expectStackDeleteSuccess({
+        stackPath: "/others/one.yml/eu-west-1",
+        stackName: "others-one",
+      })
+      .assert())
+})

--- a/packages/stacks-commands/package.json
+++ b/packages/stacks-commands/package.json
@@ -37,7 +37,8 @@
     "@takomo/util": "3.1.0",
     "aws-sdk": "2.745.0",
     "joi": "17.2.1",
-    "uuid": "3.3.3"
+    "uuid": "3.3.3",
+    "lodash.uniq": "4.5.0"
   },
   "engines": {
     "node": ">=14.4.0"

--- a/packages/stacks-commands/src/stacks/undeploy/command.ts
+++ b/packages/stacks-commands/src/stacks/undeploy/command.ts
@@ -36,6 +36,7 @@ const undeployStacks = async (
   input: StacksOperationInput,
 ): Promise<StacksOperationOutput> => {
   const modifiedInput = await modifyInput(input, ctx, io)
+
   const plan = await buildStacksUndeployPlan(
     ctx.stacks,
     input.commandPath,
@@ -65,11 +66,10 @@ export const undeployStacksCommand: CommandHandler<
   io,
 }): Promise<StacksOperationOutput> =>
   validateInput(inputSchema(ctx), input)
-    .then((input) =>
+    .then(() =>
       buildStacksContext({
         configRepository,
         ctx,
-        commandPath: input.interactive ? undefined : input.commandPath,
         logger: io,
         overrideCredentialManager: credentialManager,
       }),

--- a/packages/stacks-model/src/stack.ts
+++ b/packages/stacks-model/src/stack.ts
@@ -249,7 +249,9 @@ export const normalizeStackPath = (
   }
 
   if (!stackPath.startsWith("../")) {
-    return `${parentPath}/${stackPath}`
+    return parentPath === ROOT_STACK_GROUP_PATH
+      ? `/${stackPath}`
+      : `${parentPath}/${stackPath}`
   }
 
   if (parentPath === ROOT_STACK_GROUP_PATH) {

--- a/packages/stacks-model/test/normalize-stack-path.test.ts
+++ b/packages/stacks-model/test/normalize-stack-path.test.ts
@@ -2,6 +2,7 @@ import { normalizeStackPath } from "../src/stack"
 
 const cases = [
   ["/", "/stack.yml", "/stack.yml"],
+  ["/", "hello.yml", "/hello.yml"],
   ["/networking", "sibling.yml", "/networking/sibling.yml"],
   ["/parent", "../root-child.yml", "/root-child.yml"],
   ["/foo", "bar/baz/child.yml", "/foo/bar/baz/child.yml"],

--- a/packages/test-integration/src/commands/stacks.ts
+++ b/packages/test-integration/src/commands/stacks.ts
@@ -143,7 +143,7 @@ export const executeUndeployStacksCommand = (
       input: {
         commandPath: props.commandPath ?? ROOT_STACK_GROUP_PATH,
         timer: createTimer("total"),
-        ignoreDependencies: false,
+        ignoreDependencies: props.ignoreDependencies ?? false,
         interactive: false,
       },
     })


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/stacks-commands, @takomo/stacks-model,
@takomo/test-integration

Undeploy stacks command did not detect correctly stacks that depend on the stack that was being
undeployed.

ISSUES CLOSED: #154