### PR TITLE
fix: fix validating of allowed accounts when undeploying stacks

### DIFF
--- a/integration-tests/stacks/configs/account-ids/stacks/config.yml
+++ b/integration-tests/stacks/configs/account-ids/stacks/config.yml
@@ -1,0 +1,2 @@
+regions: eu-west-1
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole

--- a/integration-tests/stacks/configs/account-ids/stacks/vpc/one.yml
+++ b/integration-tests/stacks/configs/account-ids/stacks/vpc/one.yml
@@ -1,0 +1,2 @@
+template: template.yml
+accountIds: "{{ var.ACCOUNT_1_ID }}"

--- a/integration-tests/stacks/configs/account-ids/stacks/vpc/two.yml
+++ b/integration-tests/stacks/configs/account-ids/stacks/vpc/two.yml
@@ -1,0 +1,2 @@
+template: template.yml
+accountIds: "{{ var.OTHER_ACCOUNT_ID }}"

--- a/integration-tests/stacks/configs/account-ids/templates/template.yml
+++ b/integration-tests/stacks/configs/account-ids/templates/template.yml
@@ -1,0 +1,4 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+

--- a/integration-tests/stacks/test/account-ids.test.ts
+++ b/integration-tests/stacks/test/account-ids.test.ts
@@ -1,0 +1,128 @@
+import {
+  executeDeployStacksCommand,
+  executeUndeployStacksCommand,
+  withTestAccountIds,
+} from "@takomo/test-integration"
+import { TakomoError } from "@takomo/util"
+
+const projectDir = "configs/account-ids"
+
+describe("Account ids", () => {
+  test(
+    "Deploy should fail when credentials do not belong to the account given in accountIds",
+    withTestAccountIds((accountId) =>
+      executeDeployStacksCommand({
+        projectDir,
+        var: ["OTHER_ACCOUNT_ID=123456789012"],
+      }).expectCommandToThrow(
+        new TakomoError(
+          `Credentials associated with the stack /vpc/two.yml/eu-west-1 point to an AWS account with id ${accountId} which is not allowed in stack configuration.\n\n` +
+            "List of allowed account ids:\n\n" +
+            "- 123456789012",
+        ),
+      ),
+    ),
+  )
+
+  test(
+    "Successful deploy",
+    withTestAccountIds((accountId) =>
+      executeDeployStacksCommand({
+        projectDir,
+        var: [`OTHER_ACCOUNT_ID=${accountId}`],
+      })
+        .expectCommandToSucceed()
+        .expectStackCreateSuccess(
+          {
+            stackName: "vpc-one",
+            stackPath: "/vpc/one.yml/eu-west-1",
+          },
+          {
+            stackName: "vpc-two",
+            stackPath: "/vpc/two.yml/eu-west-1",
+          },
+        )
+        .assert(),
+    ),
+  )
+
+  test(
+    "Deploy again should fail when credentials do not belong to the account given in accountIds",
+    withTestAccountIds((accountId) =>
+      executeDeployStacksCommand({
+        projectDir,
+        var: ["OTHER_ACCOUNT_ID=666666666666"],
+      }).expectCommandToThrow(
+        new TakomoError(
+          `Credentials associated with the stack /vpc/two.yml/eu-west-1 point to an AWS account with id ${accountId} which is not allowed in stack configuration.\n\n` +
+            "List of allowed account ids:\n\n" +
+            "- 666666666666",
+        ),
+      ),
+    ),
+  )
+
+  test("Deploy should succeed when only '/vpc/one.yml/eu-west-1' is deployed", () =>
+    executeDeployStacksCommand({
+      projectDir,
+      var: ["OTHER_ACCOUNT_ID=666666666666"],
+      commandPath: "/vpc/one.yml/eu-west-1",
+    })
+      .expectCommandToSucceed()
+      .expectSuccessStackResult({
+        message: "No changes",
+        stackName: "vpc-one",
+        stackPath: "/vpc/one.yml/eu-west-1",
+      })
+      .assert())
+
+  test(
+    "Undeploy should fail when credentials do not belong to the account given in accountIds",
+    withTestAccountIds((accountId) =>
+      executeUndeployStacksCommand({
+        projectDir,
+        var: ["OTHER_ACCOUNT_ID=123412341234"],
+      }).expectCommandToThrow(
+        new TakomoError(
+          `Credentials associated with the stack /vpc/two.yml/eu-west-1 point to an AWS account with id ${accountId} which is not allowed in stack configuration.\n\n` +
+            "List of allowed account ids:\n\n" +
+            "- 123412341234",
+        ),
+      ),
+    ),
+  )
+
+  test("Undeploy should succeed when only '/vpc/one.yml/eu-west-1' is undeployed", () =>
+    executeUndeployStacksCommand({
+      projectDir,
+      var: ["OTHER_ACCOUNT_ID=666666666666"],
+      commandPath: "/vpc/one.yml/eu-west-1",
+    })
+      .expectCommandToSucceed()
+      .expectStackDeleteSuccess({
+        stackName: "vpc-one",
+        stackPath: "/vpc/one.yml/eu-west-1",
+      })
+      .assert())
+
+  test(
+    "Successful undeploy",
+    withTestAccountIds((accountId) =>
+      executeUndeployStacksCommand({
+        projectDir,
+        var: [`OTHER_ACCOUNT_ID=${accountId}`],
+      })
+        .expectCommandToSucceed()
+        .expectStackDeleteSuccess({
+          stackName: "vpc-two",
+          stackPath: "/vpc/two.yml/eu-west-1",
+        })
+        .expectSkippedStackResult({
+          message: "Stack not found",
+          stackName: "vpc-one",
+          stackPath: "/vpc/one.yml/eu-west-1",
+        })
+        .assert(),
+    ),
+  )
+})

--- a/packages/stacks-commands/src/stacks/deploy/validate.ts
+++ b/packages/stacks-commands/src/stacks/deploy/validate.ts
@@ -1,4 +1,5 @@
 import { StackStatus } from "@takomo/aws-model"
+import { validateStackCredentialManagersWithAllowedAccountIds } from "@takomo/stacks-context"
 import { TakomoError } from "@takomo/util"
 import { StackDeployOperation, StacksDeployPlan } from "./plan"
 
@@ -47,7 +48,12 @@ export const validateStacksStatus = (
 /**
  * @hidden
  */
-export const validateStacksDeployPlan = (plan: StacksDeployPlan): void => {
+export const validateStacksDeployPlan = async (
+  plan: StacksDeployPlan,
+): Promise<void> => {
   const { operations } = plan
+  await validateStackCredentialManagersWithAllowedAccountIds(
+    operations.map((o) => o.stack),
+  )
   validateStacksStatus(operations)
 }

--- a/packages/stacks-commands/src/stacks/undeploy/command.ts
+++ b/packages/stacks-commands/src/stacks/undeploy/command.ts
@@ -42,7 +42,8 @@ const undeployStacks = async (
     input.commandPath,
     input.ignoreDependencies,
   )
-  validateStacksUndeployPlan(plan)
+
+  await validateStacksUndeployPlan(plan)
   return executeUndeployContext(ctx, modifiedInput, io, plan)
 }
 

--- a/packages/stacks-commands/src/stacks/undeploy/validate.ts
+++ b/packages/stacks-commands/src/stacks/undeploy/validate.ts
@@ -1,3 +1,4 @@
+import { validateStackCredentialManagersWithAllowedAccountIds } from "@takomo/stacks-context"
 import { TakomoError } from "@takomo/util"
 import { CloudFormation } from "aws-sdk"
 import { StacksUndeployPlan, StackUndeployOperation } from "./plan"
@@ -68,8 +69,13 @@ const validateTerminationProtection = (
 /**
  * @hidden
  */
-export const validateStacksUndeployPlan = (plan: StacksUndeployPlan): void => {
+export const validateStacksUndeployPlan = async (
+  plan: StacksUndeployPlan,
+): Promise<void> => {
   const operations = plan.operations.filter((o) => o.type === "DELETE")
+  await validateStackCredentialManagersWithAllowedAccountIds(
+    operations.map((o) => o.stack),
+  )
   validateStackStatus(operations)
   validateTerminationProtection(operations)
 }

--- a/packages/stacks-context/src/config/build-stacks-context.ts
+++ b/packages/stacks-context/src/config/build-stacks-context.ts
@@ -19,10 +19,7 @@ import {
 } from "@takomo/stacks-resolvers"
 import { collectFromHierarchy, deepFreeze, TkmLogger } from "@takomo/util"
 import flatten from "lodash.flatten"
-import {
-  isStackGroupPath,
-  validateStackCredentialManagersWithAllowedAccountIds,
-} from "../common"
+import { isStackGroupPath } from "../common"
 import {
   CommandPathMatchesNoStacksError,
   StacksConfigRepository,
@@ -126,8 +123,6 @@ export const buildStacksContext = async ({
   await Promise.all(
     Array.from(credentialManagers.values()).map((cm) => cm.getCallerIdentity()),
   )
-
-  await validateStackCredentialManagersWithAllowedAccountIds(stacks)
 
   return deepFreeze({
     ...ctx,

--- a/packages/stacks-context/src/index.ts
+++ b/packages/stacks-context/src/index.ts
@@ -1,4 +1,7 @@
-export { isWithinCommandPath } from "./common"
+export {
+  isWithinCommandPath,
+  validateStackCredentialManagersWithAllowedAccountIds,
+} from "./common"
 export { buildStacksContext } from "./config/build-stacks-context"
 export {
   ConfigTree,

--- a/packages/test-integration/src/index.ts
+++ b/packages/test-integration/src/index.ts
@@ -31,4 +31,5 @@ export {
   executeUndeployTargetsCommand,
 } from "./commands/targets"
 export { TIMEOUT } from "./constants"
+export { withTestAccountIds } from "./reservations"
 export * from "./typings"

--- a/packages/test-integration/src/reservations.ts
+++ b/packages/test-integration/src/reservations.ts
@@ -1,0 +1,8 @@
+import { AccountId } from "@takomo/aws-model"
+
+export const withTestAccountIds = (
+  testFn: (...accountIds: AccountId[]) => Promise<any>,
+): (() => Promise<any>) => {
+  const ids = global.reservation.accounts.map((a) => a.accountId as AccountId)
+  return () => testFn(...ids)
+}


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/stacks-commands, @takomo/stacks-context,
@takomo/test-integration

Allowed accounts were validated even for stacks not selected for undeploy operation.
Now, only the stacks selected for undeploy are validated.

ISSUES CLOSED: #157