### PR TITLE
feat: add support to load custom parameter resolvers from NPM packages

### DIFF
--- a/integration-tests/stacks/configs/resolvers-from-npm/stacks/aaa.yml
+++ b/integration-tests/stacks/configs/resolvers-from-npm/stacks/aaa.yml
@@ -1,0 +1,12 @@
+template: hello.yml
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+regions: eu-west-1
+parameters:
+  Name:
+    resolver: custom-name
+    name: HelloHello
+  AnotherName:
+    resolver: MyCustomName
+    name: HelloHello
+  Code:
+    resolver: custom-code

--- a/integration-tests/stacks/configs/resolvers-from-npm/takomo.yml
+++ b/integration-tests/stacks/configs/resolvers-from-npm/takomo.yml
@@ -1,0 +1,11 @@
+resolvers:
+
+  # Just the package name
+  - "@takomo/test-custom-resolver-name"
+
+  # Package name in property
+  - package: "@takomo/test-custom-resolver-code"
+
+  # Package name in property and overriding name
+  - package: "@takomo/test-custom-resolver-name"
+    name: MyCustomName

--- a/integration-tests/stacks/configs/resolvers-from-npm/templates/hello.yml
+++ b/integration-tests/stacks/configs/resolvers-from-npm/templates/hello.yml
@@ -1,0 +1,19 @@
+Parameters:
+  Name:
+    Type: String
+  AnotherName:
+    Type: String
+  Code:
+    Type: Number  
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub log-${Name}-${AnotherName}-${Code}
+Outputs:
+  NameOutput:
+    Value: !Ref Name
+  AnotherNameOutput:
+    Value: !Ref AnotherName
+  CodeOutput:
+    Value: !Ref Code

--- a/integration-tests/stacks/package.json
+++ b/integration-tests/stacks/package.json
@@ -16,7 +16,7 @@
     "clean:dist": "rm -rf dist",
     "clean:deps": "rm -rf node_modules",
     "clean:all": "rm -rf node_modules dist && rm -f yarn.lock",
-    "depcheck": "depcheck --ignores=@babel/core,@babel/preset-env,@babel/preset-typescript,babel-jest,@types/jest,typescript",
+    "depcheck": "depcheck --ignores=@babel/core,@babel/preset-env,@babel/preset-typescript,babel-jest,@types/jest,typescript,@takomo/test-custom-resolver-name,@takomo/test-custom-resolver-code",
     "integration-test": "jest test --passWithNoTests --maxWorkers=10 --ci"
   },
   "dependencies": {
@@ -29,6 +29,8 @@
   "devDependencies": {
     "@types/tmp": "^0.2.0",
     "dotenv": "8.2.0",
-    "jest-environment-testenv-recycler": "0.0.12"
+    "jest-environment-testenv-recycler": "0.0.12",
+    "@takomo/test-custom-resolver-name": "0.0.1",
+    "@takomo/test-custom-resolver-code": "0.0.1"
   }
 }

--- a/integration-tests/stacks/test/resolvers-from-npm.test.ts
+++ b/integration-tests/stacks/test/resolvers-from-npm.test.ts
@@ -1,0 +1,46 @@
+import {
+  aws,
+  executeDeployStacksCommand,
+  executeUndeployStacksCommand,
+} from "@takomo/test-integration"
+import { Credentials } from "aws-sdk"
+
+const projectDir = "configs/resolvers-from-npm"
+
+const stack = {
+  stackName: "aaa",
+  stackPath: "/aaa.yml/eu-west-1",
+}
+
+describe("Custom resolvers from NPM packages", () => {
+  test("Deploy", async () => {
+    await executeDeployStacksCommand({ projectDir })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess(stack)
+      .assert()
+
+    const credentials = new Credentials(global.reservation.credentials)
+    const iamRoleArn = `arn:aws:iam::${global.reservation.accounts[0].accountId}:role/OrganizationAccountAccessRole`
+
+    const one = await aws.cloudFormation.describeStack({
+      credentials,
+      iamRoleArn,
+      region: "eu-west-1",
+      stackName: stack.stackName,
+    })
+
+    expect(
+      one.Outputs!.sort((a, b) => a.OutputKey!.localeCompare(b.OutputKey!)),
+    ).toStrictEqual([
+      { OutputKey: "AnotherNameOutput", OutputValue: "HELLOHELLO" },
+      { OutputKey: "CodeOutput", OutputValue: "123456890" },
+      { OutputKey: "NameOutput", OutputValue: "HELLOHELLO" },
+    ])
+  })
+
+  test("Undeploy", () =>
+    executeUndeployStacksCommand({ projectDir })
+      .expectCommandToSucceed()
+      .expectStackDeleteSuccess(stack)
+      .assert())
+})

--- a/packages/cli/src/cli-command-context.ts
+++ b/packages/cli/src/cli-command-context.ts
@@ -1,4 +1,4 @@
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import { FilePath } from "@takomo/util"
 
 export interface ProjectFilePaths {
@@ -24,6 +24,6 @@ export interface ProjectFilePaths {
   readonly defaultOrganizationConfigFileName: string
 }
 
-export interface CliCommandContext extends CommandContext {
+export interface CliCommandContext extends InternalCommandContext {
   readonly filePaths: ProjectFilePaths
 }

--- a/packages/cli/test/parse-external-resolvers.test.ts
+++ b/packages/cli/test/parse-external-resolvers.test.ts
@@ -1,0 +1,28 @@
+import { ExternalResolverConfig } from "@takomo/core/src"
+import { parseExternalResolvers } from "../src/config"
+
+const cases: Array<[unknown, ReadonlyArray<ExternalResolverConfig>]> = [
+  [undefined, []],
+  [null, []],
+  [[], []],
+  [["takomo-package-name"], [{ package: "takomo-package-name" }]],
+  [
+    ["takomo-package-name", "other"],
+    [{ package: "takomo-package-name" }, { package: "other" }],
+  ],
+  [[{ package: "xxxxx" }], [{ package: "xxxxx", name: undefined }]],
+  [
+    ["yyyyyyyy", { package: "a", name: undefined }],
+    [{ package: "yyyyyyyy" }, { package: "a", name: undefined }],
+  ],
+  [
+    [{ package: "xxxxx", name: "override" }],
+    [{ package: "xxxxx", name: "override" }],
+  ],
+]
+
+describe("#parseExternalResolvers", () => {
+  test.each(cases)("case %#", (given, expected) => {
+    expect(parseExternalResolvers(given)).toStrictEqual(expected)
+  })
+})

--- a/packages/cli/test/parse-project-config-file.test.ts
+++ b/packages/cli/test/parse-project-config-file.test.ts
@@ -12,6 +12,7 @@ describe("#parseProjectConfigFile", () => {
       requiredVersion: undefined,
       organization: undefined,
       regions: DEFAULT_REGIONS,
+      resolvers: [],
     })
   })
 
@@ -21,6 +22,7 @@ describe("#parseProjectConfigFile", () => {
       requiredVersion: undefined,
       organization: undefined,
       regions: ["eu-west-1"],
+      resolvers: [],
     })
   })
 
@@ -30,6 +32,29 @@ describe("#parseProjectConfigFile", () => {
       requiredVersion: undefined,
       organization: undefined,
       regions: ["eu-central-1", "eu-north-1", "us-east-1"],
+      resolvers: [],
+    })
+  })
+
+  test("with resolvers", async () => {
+    const config = await doParseProjectConfigFile("project-config-04.yml")
+    expect(config).toStrictEqual({
+      requiredVersion: undefined,
+      organization: undefined,
+      regions: ["eu-central-1", "us-east-1"],
+      resolvers: [
+        {
+          package: "@takomo/my-example-resolver",
+        },
+        {
+          package: "another-resolver",
+          name: undefined,
+        },
+        {
+          package: "another-resolver-v2",
+          name: "a-better-name",
+        },
+      ],
     })
   })
 })

--- a/packages/cli/test/project-config-04.yml
+++ b/packages/cli/test/project-config-04.yml
@@ -1,0 +1,8 @@
+regions:
+  - eu-central-1
+  - us-east-1
+resolvers:
+  - "@takomo/my-example-resolver"
+  - package: "another-resolver"
+  - package: another-resolver-v2
+    name: a-better-name

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -2,7 +2,7 @@ import { CredentialManager } from "@takomo/aws-clients"
 import { IamRoleArn, Region, ServicePrincipal } from "@takomo/aws-model"
 import { FilePath, LogLevel, Timer, TkmLogger } from "@takomo/util"
 import { Credentials } from "aws-sdk"
-import { TakomoProjectConfig } from "./config"
+import { InternalTakomoProjectConfig, TakomoProjectConfig } from "./config"
 import { Variables } from "./variables"
 
 export type Project = string
@@ -180,13 +180,20 @@ export interface CommandContext {
 /**
  * @hidden
  */
+export interface InternalCommandContext extends CommandContext {
+  readonly projectConfig: InternalTakomoProjectConfig
+}
+
+/**
+ * @hidden
+ */
 export interface CommandHandlerArgs<
   C,
   I extends IO<OUT>,
   IN extends CommandInput,
   OUT extends CommandOutput
 > {
-  readonly ctx: CommandContext
+  readonly ctx: InternalCommandContext
   readonly configRepository: C
   readonly io: I
   readonly input: IN

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -56,3 +56,18 @@ export interface TakomoProjectConfig {
   readonly organization?: TakomoProjectOrganizationConfig
   readonly regions: ReadonlyArray<Region>
 }
+
+/**
+ * @hidden
+ */
+export interface ExternalResolverConfig {
+  readonly name?: string
+  readonly package: string
+}
+
+/**
+ * @hidden
+ */
+export interface InternalTakomoProjectConfig extends TakomoProjectConfig {
+  readonly resolvers: ReadonlyArray<ExternalResolverConfig>
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export {
   CommandStatus,
   ConfirmResult,
   FAILED,
+  InternalCommandContext,
   IO,
   Project,
   resolveCommandOutputBase,
@@ -20,6 +21,8 @@ export {
 export {
   AccountRepositoryConfig,
   AccountRepositoryType,
+  ExternalResolverConfig,
+  InternalTakomoProjectConfig,
   parseCommandRole,
   parseRegex,
   parseVars,

--- a/packages/deployment-targets-commands/src/operation/process/command-path.ts
+++ b/packages/deployment-targets-commands/src/operation/process/command-path.ts
@@ -4,7 +4,7 @@ import {
   ConfigSetCommandPathOperationResult,
   ConfigSetType,
 } from "@takomo/config-sets"
-import { CommandContext, CommandRole, Variables } from "@takomo/core"
+import { CommandRole, InternalCommandContext, Variables } from "@takomo/core"
 import {
   DeploymentGroupConfig,
   DeploymentTargetConfig,
@@ -52,7 +52,7 @@ const deploy = async (
   input: StacksOperationInput,
   io: DeploymentTargetsOperationIO,
   configRepository: StacksConfigRepository,
-  ctx: CommandContext,
+  ctx: InternalCommandContext,
 ): Promise<ConfigSetCommandPathOperationResult> => {
   const result = await deployStacksCommand({
     input,
@@ -79,7 +79,7 @@ const undeploy = async (
   input: StacksOperationInput,
   io: DeploymentTargetsOperationIO,
   configRepository: StacksConfigRepository,
-  ctx: CommandContext,
+  ctx: InternalCommandContext,
 ): Promise<ConfigSetCommandPathOperationResult> => {
   const result = await undeployStacksCommand({
     input,

--- a/packages/deployment-targets-context/src/index.ts
+++ b/packages/deployment-targets-context/src/index.ts
@@ -3,7 +3,7 @@ import {
   initDefaultCredentialManager,
 } from "@takomo/aws-clients"
 import { ConfigSet, ConfigSetName } from "@takomo/config-sets"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import {
   DeploymentConfig,
   DeploymentGroupConfig,
@@ -18,7 +18,7 @@ export interface DeploymentTargetsConfigRepository
   loadDeploymentConfigFileContents: () => Promise<DeploymentConfig>
 }
 
-export interface DeploymentTargetsContext extends CommandContext {
+export interface DeploymentTargetsContext extends InternalCommandContext {
   readonly deploymentConfig: DeploymentConfig
   readonly rootDeploymentGroups: ReadonlyArray<DeploymentGroupConfig>
   readonly logger: TkmLogger
@@ -28,12 +28,12 @@ export interface DeploymentTargetsContext extends CommandContext {
   ) => DeploymentGroupConfig
   readonly hasDeploymentGroup: (path: DeploymentGroupPath) => boolean
   readonly getConfigSet: (name: ConfigSetName) => ConfigSet
-  readonly commandContext: CommandContext
+  readonly commandContext: InternalCommandContext
   readonly configRepository: DeploymentTargetsConfigRepository
 }
 
 interface CreateDeploymentTargetsContextProps {
-  readonly ctx: CommandContext
+  readonly ctx: InternalCommandContext
   readonly logger: TkmLogger
   readonly configRepository: DeploymentTargetsConfigRepository
 }

--- a/packages/organization-commands/src/accounts/operation/execute/command-path.ts
+++ b/packages/organization-commands/src/accounts/operation/execute/command-path.ts
@@ -4,7 +4,7 @@ import {
   ConfigSetName,
   ConfigSetType,
 } from "@takomo/config-sets"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import {
   OrganizationAccountConfig,
   OrganizationConfig,
@@ -36,7 +36,7 @@ const executeOperation = async (
   account: OrganizationAccountConfig,
   credentialManager: CredentialManager,
   io: AccountsOperationIO,
-  ctx: CommandContext,
+  ctx: InternalCommandContext,
   configRepository: StacksConfigRepository,
 ): Promise<StacksOperationOutput> => {
   switch (operation) {

--- a/packages/organization-context/src/build-organization-context.ts
+++ b/packages/organization-context/src/build-organization-context.ts
@@ -3,7 +3,7 @@ import {
   CredentialManager,
   initDefaultCredentialManager,
 } from "@takomo/aws-clients"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import { OrganizationConfig } from "@takomo/organization-config"
 import { TkmLogger } from "@takomo/util"
 import { OrganizationConfigRepository } from "./model"
@@ -29,7 +29,7 @@ const getCredentialManagerForOrganizationAdmin = async (
 }
 
 export const buildOrganizationContext = async (
-  ctx: CommandContext,
+  ctx: InternalCommandContext,
   configRepository: OrganizationConfigRepository,
   logger: TkmLogger,
 ): Promise<OrganizationContext> => {

--- a/packages/organization-context/src/organization-context.ts
+++ b/packages/organization-context/src/organization-context.ts
@@ -5,7 +5,7 @@ import {
 } from "@takomo/aws-clients"
 import { AccountId } from "@takomo/aws-model"
 import { ConfigSet, ConfigSetName } from "@takomo/config-sets"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import {
   OrganizationalUnitConfig,
   OrganizationConfig,
@@ -49,7 +49,7 @@ const findConfigForAccount = (
   return null
 }
 
-export interface OrganizationContext extends CommandContext {
+export interface OrganizationContext extends InternalCommandContext {
   getClient: () => OrganizationsClient
   hasOrganizationalUnit: (path: OrganizationalUnitPath) => boolean
   getOrganizationalUnit: (
@@ -60,14 +60,14 @@ export interface OrganizationContext extends CommandContext {
   getConfigSet: (name: ConfigSetName) => ConfigSet
   configRepository: OrganizationConfigRepository
   credentialManager: CredentialManager
-  commandContext: CommandContext
+  commandContext: InternalCommandContext
 }
 
 export interface OrganizationContextProps {
   readonly organizationAdminCredentialManager: CredentialManager
   readonly credentialManager: CredentialManager
   readonly organizationConfig: OrganizationConfig
-  readonly ctx: CommandContext
+  readonly ctx: InternalCommandContext
   readonly configRepository: OrganizationConfigRepository
   readonly logger: TkmLogger
 }

--- a/packages/stacks-context/src/config/build-stacks-context.ts
+++ b/packages/stacks-context/src/config/build-stacks-context.ts
@@ -3,7 +3,7 @@ import {
   initDefaultCredentialManager,
 } from "@takomo/aws-clients"
 import { IamRoleArn } from "@takomo/aws-model"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import {
   CommandPath,
   createSchemaRegistry,
@@ -37,7 +37,7 @@ import { processConfigTree } from "./process-config-tree"
 
 export interface BuildConfigContextInput {
   readonly configRepository: StacksConfigRepository
-  readonly ctx: CommandContext
+  readonly ctx: InternalCommandContext
   readonly logger: TkmLogger
   readonly overrideCredentialManager?: CredentialManager
   readonly commandPath?: CommandPath
@@ -92,6 +92,10 @@ export const buildStacksContext = async ({
   coreResolverProviders().forEach((p) =>
     resolverRegistry.registerBuiltInProvider(p),
   )
+
+  ctx.projectConfig.resolvers.forEach((config) => {
+    resolverRegistry.registerProviderFromNpmPackage(config)
+  })
 
   const schemaRegistry = createSchemaRegistry(logger)
 

--- a/packages/stacks-resolvers/src/resolver-registry.ts
+++ b/packages/stacks-resolvers/src/resolver-registry.ts
@@ -1,5 +1,5 @@
 import { StackParameterKey } from "@takomo/aws-model"
-import { CommandContext } from "@takomo/core"
+import { CommandContext, ExternalResolverConfig } from "@takomo/core"
 import { ParameterConfig } from "@takomo/stacks-config"
 import {
   Resolver,
@@ -101,6 +101,16 @@ export class ResolverRegistry {
     provider: ResolverProvider,
   ): Promise<void> => {
     return this.registerProvider(provider, "built-in providers")
+  }
+
+  registerProviderFromNpmPackage = (config: ExternalResolverConfig): void => {
+    // eslint-disable-next-line
+    const provider = require(config.package)
+    const providerWithName = config.name
+      ? { ...provider, name: config.name }
+      : provider
+
+    this.registerProvider(providerWithName, `npm package: ${config.package}`)
   }
 
   getRegisteredResolverNames = (): ResolverName[] =>

--- a/packages/test-integration/src/commands/init.ts
+++ b/packages/test-integration/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { Region } from "@takomo/aws-model"
 import { createFileSystemProjectConfigRepository } from "@takomo/config-repository-fs"
-import { CommandContext, Project } from "@takomo/core"
+import { InternalCommandContext, Project } from "@takomo/core"
 import {
   initProjectCommand,
   ProjectConfigRepository,
@@ -29,7 +29,7 @@ export const createTestProjectConfigRepository = async ({
   })
 
 interface CtxAndConfigRepository {
-  ctx: CommandContext
+  ctx: InternalCommandContext
   configRepository: ProjectConfigRepository
 }
 

--- a/packages/test-integration/src/commands/organization.ts
+++ b/packages/test-integration/src/commands/organization.ts
@@ -4,7 +4,7 @@ import {
   OrganizationFeatureSet,
 } from "@takomo/aws-model"
 import { createFileSystemOrganizationConfigRepository } from "@takomo/config-repository-fs"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import {
   accountsOperationCommand,
   createAccountAliasCommand,
@@ -52,7 +52,7 @@ import {
 } from "./stacks"
 
 interface CtxAndConfigRepository {
-  ctx: CommandContext
+  ctx: InternalCommandContext
   configRepository: OrganizationConfigRepository
 }
 

--- a/packages/test-integration/src/commands/stacks.ts
+++ b/packages/test-integration/src/commands/stacks.ts
@@ -1,6 +1,6 @@
 import { CliCommandContext } from "@takomo/cli"
 import { createFileSystemStacksConfigRepository } from "@takomo/config-repository-fs"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import {
   deployStacksCommand,
   listStacksCommand,
@@ -54,7 +54,7 @@ export const createTestStacksConfigRepository = async ({
   })
 
 interface CtxAndConfigRepository {
-  ctx: CommandContext
+  ctx: InternalCommandContext
   configRepository: StacksConfigRepository
 }
 

--- a/packages/test-integration/src/commands/targets.ts
+++ b/packages/test-integration/src/commands/targets.ts
@@ -1,6 +1,6 @@
 import { CliCommandContext } from "@takomo/cli"
 import { createFileSystemDeploymentTargetsConfigRepository } from "@takomo/config-repository-fs"
-import { CommandContext } from "@takomo/core"
+import { InternalCommandContext } from "@takomo/core"
 import { deploymentTargetsOperationCommand } from "@takomo/deployment-targets-commands"
 import { DeploymentTargetsConfigRepository } from "@takomo/deployment-targets-context"
 import { createConsoleLogger, createTimer } from "@takomo/util"
@@ -18,7 +18,7 @@ import { createTestCommandContext, ExecuteCommandProps } from "./common"
 import { CreateCtxAndConfigRepositoryProps } from "./stacks"
 
 interface CtxAndConfigRepository {
-  readonly ctx: CommandContext
+  readonly ctx: InternalCommandContext
   readonly configRepository: DeploymentTargetsConfigRepository
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,16 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@takomo/test-custom-resolver-code@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@takomo/test-custom-resolver-code/-/test-custom-resolver-code-0.0.1.tgz#9179965f9986df2bec9cc3347956f34529a520b6"
+  integrity sha512-Ngk258oCtKX8/Wi+YWliX7jIjuy9CX8jvPGBhWNJ4KiI2FTumTMvRaq+TuOpCxZrFYXJ7WMOgsjHcFPhdZwolg==
+
+"@takomo/test-custom-resolver-name@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@takomo/test-custom-resolver-name/-/test-custom-resolver-name-0.0.1.tgz#173d46115602e47f228ca42e656cd84dd7a1a5f1"
+  integrity sha512-qE5dn49nXnkJN0itNSmNd3dCefwrVxNNlO1/ty2KVYPHhPNjRo4q4xm4ccubc9NYchpOTCqiSS38PghznjXCrw==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/cli, @takomo/core, @takomo/deployment-targets-commands,
@takomo/deployment-targets-context, @takomo/organization-commands, @takomo/organization-context,
@takomo/stacks-context, @takomo/stacks-resolvers, @takomo/test-integration

ISSUES CLOSED: #163