### PR TITLE
feat(hooks): add option to expose stack aws crendentials to cmd hook

### DIFF
--- a/integration-tests/stacks/configs/cmd-hook-expose-stack-credentials/get-caller-identity.sh
+++ b/integration-tests/stacks/configs/cmd-hook-expose-stack-credentials/get-caller-identity.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+aws sts get-caller-identity --output text --query Account

--- a/integration-tests/stacks/configs/cmd-hook-expose-stack-credentials/stacks/hooks.yml
+++ b/integration-tests/stacks/configs/cmd-hook-expose-stack-credentials/stacks/hooks.yml
@@ -1,0 +1,7 @@
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+regions: eu-central-1
+hooks:
+  - name: hook1
+    type: cmd
+    command: ./get-caller-identity.sh
+    exposeStackCredentials: {{ var.exposeStackCredentials }}

--- a/integration-tests/stacks/configs/cmd-hook-expose-stack-credentials/templates/hooks.yml
+++ b/integration-tests/stacks/configs/cmd-hook-expose-stack-credentials/templates/hooks.yml
@@ -1,0 +1,4 @@
+Description: hook1={{ hooks.hook1 }}
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/test/cmd-hook-expose-stack-credentials.test.ts
+++ b/integration-tests/stacks/test/cmd-hook-expose-stack-credentials.test.ts
@@ -1,0 +1,52 @@
+import {
+  aws,
+  executeDeployStacksCommand,
+  withTestReservation,
+} from "@takomo/test-integration"
+
+const projectDir = "configs/cmd-hook-expose-stack-credentials"
+
+describe("Cmd hook that exposes stack credentials", () => {
+  test("Deploy without exposing credentials fails", () =>
+    executeDeployStacksCommand({
+      projectDir,
+      var: ["exposeStackCredentials=false"],
+    })
+      .expectCommandToFail("Failed")
+      .expectFailureStackResult({
+        stackName: "hooks",
+        stackPath: "/hooks.yml/eu-central-1",
+        errorMessage:
+          "Command failed: ./get-caller-identity.sh\n" +
+          'Unable to locate credentials. You can configure credentials by running "aws configure".\n',
+        message: "Error",
+      })
+      .assert())
+
+  test(
+    "Deploy with exposing credentials succeeds",
+    withTestReservation(async ({ accountIds, credentials }) => {
+      await executeDeployStacksCommand({
+        projectDir,
+        var: ["exposeStackCredentials=true"],
+      })
+        .expectCommandToSucceed()
+        .expectStackCreateSuccess({
+          stackName: "hooks",
+          stackPath: "/hooks.yml/eu-central-1",
+        })
+        .assert()
+
+      const iamRoleArn = `arn:aws:iam::${accountIds[0]}:role/OrganizationAccountAccessRole`
+
+      const stack = await aws.cloudFormation.describeStack({
+        credentials,
+        iamRoleArn,
+        region: "eu-central-1",
+        stackName: "hooks",
+      })
+
+      expect(stack.Description).toBe(`hook1=${accountIds[0]}`)
+    }),
+  )
+})

--- a/integration-tests/stacks/test/sam.test.ts
+++ b/integration-tests/stacks/test/sam.test.ts
@@ -22,6 +22,7 @@ const deploy = (
     answers: {
       confirmStackDeploy: "CONTINUE",
       confirmDeploy: "CONTINUE_AND_REVIEW",
+      chooseCommandPath: "/",
     },
   })
 
@@ -30,7 +31,7 @@ const undeploy = (autoConfirmEnabled: boolean): StacksOperationOutputMatcher =>
     autoConfirmEnabled,
     projectDir: "configs/sam",
     var: [`timeout=1`],
-    answers: { confirmUndeploy: "CONTINUE" },
+    answers: { confirmUndeploy: "CONTINUE", chooseCommandPath: "/" },
   })
 
 const stackName = "sam"

--- a/packages/stacks-commands/src/stacks/deploy/steps/execute-after-deploy-hooks.ts
+++ b/packages/stacks-commands/src/stacks/deploy/steps/execute-after-deploy-hooks.ts
@@ -19,8 +19,9 @@ export const executeAfterDeployHooks: StackOperationStep<StackOperationResultHol
     transitions,
   } = state
 
-  const { success, message } = await executeHooks(
+  const { success, message, error } = await executeHooks(
     ctx,
+    stack,
     variables,
     stack.hooks,
     toHookOperation(operationType),
@@ -31,7 +32,7 @@ export const executeAfterDeployHooks: StackOperationStep<StackOperationResultHol
 
   if (!success) {
     logger.error(`After launch hooks failed with message: ${message}`)
-    return transitions.failStackOperation({ ...state, message })
+    return transitions.failStackOperation({ ...state, message, error })
   }
 
   return transitions.completeStackOperation(state)

--- a/packages/stacks-commands/src/stacks/deploy/steps/execute-before-deploy-hooks.ts
+++ b/packages/stacks-commands/src/stacks/deploy/steps/execute-before-deploy-hooks.ts
@@ -11,8 +11,9 @@ export const executeBeforeDeployHooks: StackOperationStep<DetailedCurrentStackHo
 ) => {
   const { stack, operationType, ctx, variables, logger, transitions } = state
 
-  const { success, message } = await executeHooks(
+  const { success, message, error } = await executeHooks(
     ctx,
+    stack,
     variables,
     stack.hooks,
     toHookOperation(operationType),
@@ -22,7 +23,12 @@ export const executeBeforeDeployHooks: StackOperationStep<DetailedCurrentStackHo
 
   if (!success) {
     logger.error(`Before deploy hooks failed with message: ${message}`)
-    return transitions.failStackOperation({ ...state, message, events: [] })
+    return transitions.failStackOperation({
+      ...state,
+      message,
+      error,
+      events: [],
+    })
   }
 
   return transitions.prepareParameters(state)

--- a/packages/stacks-commands/src/stacks/undeploy/steps/execute-after-undeploy-hooks.ts
+++ b/packages/stacks-commands/src/stacks/undeploy/steps/execute-after-undeploy-hooks.ts
@@ -10,8 +10,9 @@ export const executeAfterUndeployHooks: StackOperationStep<StackOperationResultH
 ) => {
   const { stack, ctx, variables, logger, transitions, events } = state
 
-  const { success, message } = await executeHooks(
+  const { success, message, error } = await executeHooks(
     ctx,
+    stack,
     variables,
     stack.hooks,
     "delete",
@@ -21,7 +22,7 @@ export const executeAfterUndeployHooks: StackOperationStep<StackOperationResultH
 
   if (!success) {
     logger.error(`After undeploy hooks failed with message: ${message}`)
-    return transitions.failStackOperation({ ...state, message, events })
+    return transitions.failStackOperation({ ...state, message, events, error })
   }
 
   return transitions.completeStackOperation(state)

--- a/packages/stacks-commands/src/stacks/undeploy/steps/execute-before-undeploy-hooks.ts
+++ b/packages/stacks-commands/src/stacks/undeploy/steps/execute-before-undeploy-hooks.ts
@@ -10,8 +10,9 @@ export const executeBeforeUndeployHooks: StackOperationStep<CurrentStackHolder> 
 ) => {
   const { stack, ctx, variables, logger, transitions } = state
 
-  const { success, message } = await executeHooks(
+  const { success, message, error } = await executeHooks(
     ctx,
+    stack,
     variables,
     stack.hooks,
     "delete",
@@ -21,7 +22,12 @@ export const executeBeforeUndeployHooks: StackOperationStep<CurrentStackHolder> 
 
   if (!success) {
     logger.error(`Before undeploy hooks failed with message: ${message}`)
-    return transitions.failStackOperation({ ...state, message, events: [] })
+    return transitions.failStackOperation({
+      ...state,
+      message,
+      error,
+      events: [],
+    })
   }
 
   return transitions.initiateStackDelete(state)

--- a/packages/stacks-hooks/src/execute.ts
+++ b/packages/stacks-hooks/src/execute.ts
@@ -5,6 +5,7 @@ import {
   HookStage,
   HookStatus,
   InternalStacksContext,
+  Stack,
   StackOperationVariables,
 } from "@takomo/stacks-model"
 import { TkmLogger } from "@takomo/util"
@@ -14,6 +15,7 @@ import { TkmLogger } from "@takomo/util"
  */
 export const executeHooks = async (
   ctx: InternalStacksContext,
+  stack: Stack,
   variables: StackOperationVariables,
   hooks: ReadonlyArray<HookExecutor>,
   operation: HookOperation,
@@ -27,10 +29,12 @@ export const executeHooks = async (
 
   const input = {
     ctx,
+    stack,
     variables,
     stage,
     operation,
     status,
+    logger,
   }
 
   const hooksToExecute = hooks.filter((h) => h.match(input))
@@ -55,6 +59,7 @@ export const executeHooks = async (
         return {
           message: output.message || "Failed",
           success: false,
+          error: output.error,
         }
       }
     } catch (e) {
@@ -65,6 +70,7 @@ export const executeHooks = async (
       return {
         message: e.message || "Error",
         success: false,
+        error: e,
       }
     }
   }

--- a/packages/stacks-hooks/test/execute-hooks.test.ts
+++ b/packages/stacks-hooks/test/execute-hooks.test.ts
@@ -5,6 +5,7 @@ import {
   HookOutput,
   HooksExecutionOutput,
   InternalStacksContext,
+  Stack,
   StackOperationVariables,
 } from "@takomo/stacks-model"
 import { createConsoleLogger } from "@takomo/util"
@@ -65,32 +66,31 @@ const createVariables = (): StackOperationVariables => ({
 
 const logger = createConsoleLogger({
   logLevel: "info",
-  concealConfidentialInformation: true,
 })
 
 const executor = (name: string, hook: Hook): HookExecutor =>
   new HookExecutor(
     {
-      operation: null,
-      status: null,
-      stage: null,
       name,
       type: "cmd",
     },
     hook,
   )
 
+const stack = mock<Stack>()
+
 const executeAllHooks = async (
   variables: StackOperationVariables,
   ...executors: HookExecutor[]
 ): Promise<HooksExecutionOutput> =>
-  executeHooks(ctx, variables, executors, "create", "before", logger)
+  executeHooks(ctx, stack, variables, executors, "create", "before", logger)
 
 describe("#executeHooks", () => {
   describe("when no hooks are given", () => {
     test("returns success", async () => {
       const result = await executeHooks(
         ctx,
+        stack,
         createVariables(),
         [],
         "create",
@@ -109,9 +109,6 @@ describe("#executeHooks", () => {
       const hook1 = new TestHook(true)
       const hook1Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock1",
           type: "cmd",
         },
@@ -120,6 +117,7 @@ describe("#executeHooks", () => {
 
       const result = await executeHooks(
         ctx,
+        stack,
         createVariables(),
         [hook1Executor],
         "create",
@@ -141,9 +139,6 @@ describe("#executeHooks", () => {
 
       const hook1Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock1",
           type: "cmd",
         },
@@ -152,6 +147,7 @@ describe("#executeHooks", () => {
 
       const result = await executeHooks(
         ctx,
+        stack,
         createVariables(),
         [hook1Executor],
         "create",
@@ -161,6 +157,7 @@ describe("#executeHooks", () => {
       expect(result).toStrictEqual({
         success: false,
         message: "Error error!",
+        error: undefined,
       })
 
       expect(hook1.executed).toBe(true)
@@ -174,7 +171,6 @@ describe("#executeHooks", () => {
       const hook1Executor = new HookExecutor(
         {
           operation: ["create"],
-          status: null,
           stage: ["before"],
           name: "mock1",
           type: "cmd",
@@ -187,7 +183,6 @@ describe("#executeHooks", () => {
       const hook2Executor = new HookExecutor(
         {
           operation: ["delete"],
-          status: null,
           stage: ["after"],
           name: "mock2",
           type: "cmd",
@@ -199,9 +194,6 @@ describe("#executeHooks", () => {
 
       const hook3Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock3",
           type: "cmd",
         },
@@ -210,6 +202,7 @@ describe("#executeHooks", () => {
 
       const result = await executeHooks(
         ctx,
+        stack,
         createVariables(),
         [hook1Executor, hook2Executor, hook3Executor],
         "delete",
@@ -237,9 +230,6 @@ describe("#executeHooks", () => {
 
       const hook1Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock1",
           type: "cmd",
         },
@@ -248,9 +238,6 @@ describe("#executeHooks", () => {
 
       const hook2Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock2",
           type: "cmd",
         },
@@ -259,9 +246,6 @@ describe("#executeHooks", () => {
 
       const hook3Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock3",
           type: "cmd",
         },
@@ -270,9 +254,6 @@ describe("#executeHooks", () => {
 
       const hook4Executor = new HookExecutor(
         {
-          operation: null,
-          status: null,
-          stage: null,
           name: "mock4",
           type: "cmd",
         },
@@ -283,6 +264,7 @@ describe("#executeHooks", () => {
 
       const result = await executeHooks(
         ctx,
+        stack,
         variables,
         [hook1Executor, hook2Executor, hook3Executor, hook4Executor],
         "delete",

--- a/packages/stacks-model/src/hook.ts
+++ b/packages/stacks-model/src/hook.ts
@@ -1,5 +1,7 @@
+import { TkmLogger } from "@takomo/util"
 import { StackOperationVariables } from "./command"
 import { StacksContext } from "./context"
+import { Stack } from "./stack"
 
 export type HookInitializer = (props: any) => Promise<Hook>
 
@@ -40,6 +42,11 @@ export interface HooksExecutionOutput {
    * Boolean describing if the action was successful.
    */
   readonly success: boolean
+
+  /**
+   * If an error was thrown during execution it will be stored here.
+   */
+  readonly error?: Error
 }
 
 /**
@@ -47,10 +54,12 @@ export interface HooksExecutionOutput {
  */
 export interface HookInput {
   readonly ctx: StacksContext
+  readonly stack: Stack
   readonly variables: StackOperationVariables
   readonly stage: HookStage
   readonly operation: HookOperation
   readonly status?: HookStatus
+  readonly logger: TkmLogger
 }
 
 /**
@@ -71,6 +80,11 @@ export interface HookOutputObject {
    * Optional return value.
    */
   readonly value?: any
+
+  /**
+   * Optional return value.
+   */
+  readonly error?: Error
 }
 
 /**

--- a/packages/test-integration/src/index.ts
+++ b/packages/test-integration/src/index.ts
@@ -31,5 +31,9 @@ export {
   executeUndeployTargetsCommand,
 } from "./commands/targets"
 export { TIMEOUT } from "./constants"
-export { withTestAccountIds } from "./reservations"
+export {
+  TestReservation,
+  withTestAccountIds,
+  withTestReservation,
+} from "./reservations"
 export * from "./typings"

--- a/packages/test-integration/src/reservations.ts
+++ b/packages/test-integration/src/reservations.ts
@@ -1,8 +1,22 @@
 import { AccountId } from "@takomo/aws-model"
+import { Credentials } from "aws-sdk"
 
 export const withTestAccountIds = (
   testFn: (...accountIds: AccountId[]) => Promise<any>,
 ): (() => Promise<any>) => {
   const ids = global.reservation.accounts.map((a) => a.accountId as AccountId)
   return () => testFn(...ids)
+}
+
+export interface TestReservation {
+  readonly credentials: Credentials
+  readonly accountIds: ReadonlyArray<AccountId>
+}
+
+export const withTestReservation = (
+  testFn: (reservation: TestReservation) => Promise<any>,
+): (() => Promise<any>) => {
+  const credentials = new Credentials(global.reservation.credentials)
+  const accountIds = global.reservation.accounts.map((a) => a.accountId!)
+  return () => testFn({ credentials, accountIds })
 }


### PR DESCRIPTION
affects: @takomo/stacks-commands, @takomo/stacks-hooks, @takomo/stacks-model

ISSUES CLOSED: #177