### PR TITLE
feat(deployment targets): add support to configure validation schemas…

### DIFF
--- a/packages/aws-model/src/common.ts
+++ b/packages/aws-model/src/common.ts
@@ -50,6 +50,7 @@ export type UserId = string
  * IAM role arn
  */
 export type IamRoleArn = string
+export type IamRoleName = string
 
 export type AccountAlias = string
 export type AccountEmail = string

--- a/packages/aws-model/src/index.ts
+++ b/packages/aws-model/src/index.ts
@@ -60,6 +60,7 @@ export {
   Arn,
   ClientRequestToken,
   IamRoleArn,
+  IamRoleName,
   Region,
   ServicePrincipal,
   Tag,

--- a/packages/deployment-targets-commands/src/operation/process/command-path.ts
+++ b/packages/deployment-targets-commands/src/operation/process/command-path.ts
@@ -219,7 +219,7 @@ export const processCommandPath = async (
   }
 
   const mergedVars = deepCopy(variables.var)
-  merge(mergedVars, deploymentConfig.vars, group.vars, target.vars)
+  merge(mergedVars, target.vars)
 
   const commandPathVariables = {
     env: variables.env,

--- a/packages/deployment-targets-config/src/model.ts
+++ b/packages/deployment-targets-config/src/model.ts
@@ -1,4 +1,4 @@
-import { AccountId } from "@takomo/aws-model"
+import { AccountId, IamRoleName } from "@takomo/aws-model"
 import { ConfigSet, ConfigSetName } from "@takomo/config-sets"
 import { CommandRole, Vars } from "@takomo/core"
 import {
@@ -8,6 +8,11 @@ import {
   DeploymentTargetName,
 } from "@takomo/deployment-targets-model"
 
+export interface SchemaConfig {
+  readonly name: string
+  readonly [key: string]: unknown
+}
+
 export interface DeploymentTargetConfig {
   readonly status: DeploymentStatus
   readonly name: DeploymentTargetName
@@ -16,9 +21,9 @@ export interface DeploymentTargetConfig {
   readonly configSets: ReadonlyArray<ConfigSetName>
   readonly bootstrapConfigSets: ReadonlyArray<ConfigSetName>
   readonly deploymentRole?: CommandRole
-  readonly deploymentRoleName?: string
+  readonly deploymentRoleName?: IamRoleName
   readonly bootstrapRole?: CommandRole
-  readonly bootstrapRoleName?: string
+  readonly bootstrapRoleName?: IamRoleName
   readonly accountId?: AccountId
 }
 
@@ -30,16 +35,18 @@ export interface DeploymentGroupConfig {
   readonly priority: number
   readonly status: DeploymentStatus
   readonly vars: Vars
+  readonly targetsSchema: ReadonlyArray<SchemaConfig>
   readonly configSets: ReadonlyArray<ConfigSetName>
   readonly bootstrapConfigSets: ReadonlyArray<ConfigSetName>
   readonly children: ReadonlyArray<DeploymentGroupConfig>
   readonly deploymentRole?: CommandRole
-  readonly deploymentRoleName?: string
+  readonly deploymentRoleName?: IamRoleName
   readonly bootstrapRole?: CommandRole
-  readonly bootstrapRoleName?: string
+  readonly bootstrapRoleName?: IamRoleName
 }
 
 export interface DeploymentConfig {
+  readonly targetsSchema: ReadonlyArray<SchemaConfig>
   readonly configSets: ReadonlyArray<ConfigSet>
   readonly vars: Vars
   readonly deploymentGroups: ReadonlyArray<DeploymentGroupConfig>

--- a/packages/deployment-targets-config/src/schema.ts
+++ b/packages/deployment-targets-config/src/schema.ts
@@ -23,9 +23,15 @@ export const createDeploymentTargetsConfigSchema = (
 
   const targets = Joi.array().items(deploymentTarget)
 
+  const targetsSchema = [
+    Joi.string(),
+    Joi.object({ name: Joi.string().required() }).unknown(true),
+  ]
+
   const deploymentGroup = Joi.object({
     vars,
     targets,
+    targetsSchema,
     description: Joi.string(),
     deploymentRole: iamRoleArn,
     deploymentRoleName: iamRoleName,
@@ -45,6 +51,7 @@ export const createDeploymentTargetsConfigSchema = (
     .required()
 
   return Joi.object({
+    targetsSchema,
     vars,
     deploymentGroups,
     configSets,

--- a/packages/deployment-targets-config/test/build-deployment-config.test.ts
+++ b/packages/deployment-targets-config/test/build-deployment-config.test.ts
@@ -1,4 +1,6 @@
 import { CommandContext } from "@takomo/core"
+import { DeploymentTargetsSchemaRegistry } from "@takomo/deployment-targets-model"
+import { TkmLogger } from "@takomo/util"
 import { parseYaml } from "@takomo/util/src"
 import { readFileSync } from "fs"
 import { mock } from "jest-mock-extended"
@@ -15,25 +17,40 @@ const readConfig = (file: string) =>
     ).toString("utf-8"),
   )
 
+const logger = mock<TkmLogger>()
+const schemaRegistry = mock<DeploymentTargetsSchemaRegistry>()
+
 describe("#buildDeploymentConfig", () => {
-  test("Single deployment group", () => {
+  test("Single deployment group", async () => {
     const externalTargets = new Map()
     const record = readConfig("01.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
     if (result.isErr()) {
       fail("Expected result to be ok")
     }
     expect(result.value.deploymentGroups).toHaveLength(1)
   })
 
-  test("Single deployment group with single external deployment target", () => {
+  test("Single deployment group with single external deployment target", async () => {
     const target1 = {
       deploymentGroupPath: "group1",
       name: "target1",
     }
     const externalTargets = new Map([["group1", [target1]]])
     const record = readConfig("01.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
     if (result.isErr()) {
       fail("Expected result to be ok")
     }
@@ -43,7 +60,7 @@ describe("#buildDeploymentConfig", () => {
     expect(targets).toHaveLength(1)
   })
 
-  test("Single deployment group with multiple external deployment targets", () => {
+  test("Single deployment group with multiple external deployment targets", async () => {
     const target1 = {
       deploymentGroupPath: "group1",
       name: "target1",
@@ -58,7 +75,13 @@ describe("#buildDeploymentConfig", () => {
     }
     const externalTargets = new Map([["group1", [target1, target2, target3]]])
     const record = readConfig("01.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
     if (result.isErr()) {
       fail("Expected result to be ok")
     }
@@ -68,7 +91,7 @@ describe("#buildDeploymentConfig", () => {
     expect(targets).toHaveLength(3)
   })
 
-  test("Deployment groups with multiple external deployment targets", () => {
+  test("Deployment groups with multiple external deployment targets", async () => {
     const target1 = {
       deploymentGroupPath: "group1",
       name: "target1",
@@ -95,7 +118,13 @@ describe("#buildDeploymentConfig", () => {
       ["group3", [target4]],
     ])
     const record = readConfig("02.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
     if (result.isErr()) {
       fail("Expected result to be ok")
     }
@@ -120,7 +149,7 @@ describe("#buildDeploymentConfig", () => {
     expect(group3Targets[0].name).toStrictEqual("target4")
   })
 
-  test("An error is returned if external deployment targets refer to groups not found from the configuration", () => {
+  test("An error is returned if external deployment targets refer to groups not found from the configuration", async () => {
     const target1 = {
       deploymentGroupPath: "group1",
       name: "target1",
@@ -138,7 +167,13 @@ describe("#buildDeploymentConfig", () => {
       ["group3", [target2]],
     ])
     const record = readConfig("01.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
 
     if (result.isOk()) {
       fail("Expected result to be error")
@@ -153,7 +188,7 @@ describe("#buildDeploymentConfig", () => {
     )
   })
 
-  test("An error is returned if external deployment target names are not unique", () => {
+  test("An error is returned if external deployment target names are not unique", async () => {
     const target1 = {
       deploymentGroupPath: "group1",
       name: "target1",
@@ -164,7 +199,13 @@ describe("#buildDeploymentConfig", () => {
     }
     const externalTargets = new Map([["group1", [target1, target2]]])
     const record = readConfig("01.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
 
     if (result.isOk()) {
       fail("Expected result to be error")
@@ -179,10 +220,16 @@ describe("#buildDeploymentConfig", () => {
     )
   })
 
-  test("An error is returned if target names are not unique", () => {
+  test("An error is returned if target names are not unique", async () => {
     const externalTargets = new Map()
     const record = readConfig("03.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
 
     if (result.isOk()) {
       fail("Expected result to be error")
@@ -197,14 +244,20 @@ describe("#buildDeploymentConfig", () => {
     )
   })
 
-  test("An error is returned if target names are not unique #2", () => {
+  test("An error is returned if target names are not unique #2", async () => {
     const target1 = {
       deploymentGroupPath: "group1",
       name: "foobar",
     }
     const externalTargets = new Map([["group1", [target1]]])
     const record = readConfig("04.yml")
-    const result = buildDeploymentConfig(ctx, externalTargets, record)
+    const result = await buildDeploymentConfig(
+      ctx,
+      logger,
+      schemaRegistry,
+      externalTargets,
+      record,
+    )
 
     if (result.isOk()) {
       fail("Expected result to be error")

--- a/packages/deployment-targets-model/package.json
+++ b/packages/deployment-targets-model/package.json
@@ -26,6 +26,13 @@
     "test": "jest test --passWithNoTests --verbose",
     "watch": "tsc -p tsconfig.build.json --watch"
   },
+  "dependencies": {
+    "@takomo/core": "3.5.1",
+    "@takomo/stacks-model": "3.5.1",
+    "@takomo/util": "3.4.0",
+    "joi": "17.2.1"
+
+  },
   "engines": {
     "node": ">=14.4.0"
   },

--- a/packages/deployment-targets-model/src/index.ts
+++ b/packages/deployment-targets-model/src/index.ts
@@ -1,4 +1,83 @@
+import { CommandContext } from "@takomo/core"
+import {
+  createSchemaRegistry,
+  defaultSchema,
+  SchemaName,
+  SchemaRegistry,
+} from "@takomo/stacks-model"
+import { deepFreeze, TakomoError, TkmLogger } from "@takomo/util"
+import Joi, { AnySchema } from "joi"
+
 export type DeploymentGroupName = string
 export type DeploymentTargetName = string
 export type DeploymentGroupPath = string
 export type DeploymentStatus = "active" | "disabled"
+
+/**
+ * @hidden
+ */
+export interface DeploymentTargetsSchemaRegistry extends SchemaRegistry {
+  readonly initDeploymentTargetsSchema: (
+    ctx: CommandContext,
+    deploymentGroupPath: DeploymentGroupPath,
+    name: SchemaName,
+    props: Record<string, unknown>,
+  ) => Promise<AnySchema>
+}
+
+/**
+ * @hidden
+ */
+export const createDeploymentTargetsSchemaRegistry = (
+  logger: TkmLogger,
+): DeploymentTargetsSchemaRegistry => {
+  const schemaRegistry = createSchemaRegistry(logger)
+  return deepFreeze({
+    ...schemaRegistry,
+    initDeploymentTargetsSchema: async (
+      ctx: CommandContext,
+      deploymentGroupPath: DeploymentGroupPath,
+      name: SchemaName,
+      props: Record<string, unknown>,
+    ): Promise<AnySchema> => {
+      logger.debug(
+        `Initialize schema '${name}' for deployment group '${deploymentGroupPath}'`,
+      )
+      const provider = schemaRegistry.getProvider(name)
+      if (!provider) {
+        throw new Error(`Provider not found for schema '${name}'`)
+      }
+
+      if (provider.schema) {
+        const schema = provider.schema({
+          ctx,
+          joi: Joi.defaults((schema) => schema),
+          base: defaultSchema(name),
+        })
+
+        if (!Joi.isSchema(schema)) {
+          throw new TakomoError(
+            `Error initializing schema '${name}' for deployment group '${deploymentGroupPath}':\n\n` +
+              `  - value returned from schema function is not a Joi schema object`,
+          )
+        }
+
+        const { error } = schema.validate(props, { abortEarly: false })
+        if (error) {
+          const details = error.details
+            .map((d) => `  - ${d.message}`)
+            .join("\n")
+          throw new TakomoError(
+            `${error.details.length} validation error(s) in schema '${name}' configuration for deployment group '${deploymentGroupPath}':\n\n${details}`,
+          )
+        }
+      }
+
+      return provider.init({
+        joi: Joi.defaults((schema) => schema),
+        ctx,
+        props,
+      })
+    },
+  })
+}

--- a/packages/stacks-model/src/index.ts
+++ b/packages/stacks-model/src/index.ts
@@ -6,6 +6,7 @@ export * from "./hook"
 export * from "./resolver"
 export {
   createSchemaRegistry,
+  defaultSchema,
   InitSchemaProps,
   SchemaName,
   SchemaProps,

--- a/packages/stacks-model/src/schemas.ts
+++ b/packages/stacks-model/src/schemas.ts
@@ -59,6 +59,7 @@ export interface SchemaRegistry {
     pathToResolverFile: FilePath,
   ) => Promise<void>
   readonly hasProvider: (name: SchemaName) => boolean
+  readonly getProvider: (name: SchemaName) => SchemaProvider | undefined
 }
 
 /**
@@ -74,6 +75,10 @@ export const defaultSchema = (schemaName: SchemaName): Joi.ObjectSchema =>
  */
 export const createSchemaRegistry = (logger: TkmLogger): SchemaRegistry => {
   const schemas = new Map<SchemaName, SchemaProvider>()
+
+  const getProvider = (name: SchemaName): SchemaProvider | undefined =>
+    schemas.get(name)
+
   return deepFreeze({
     registerProviderFromFile: async (
       pathToProviderFile: FilePath,
@@ -125,6 +130,8 @@ export const createSchemaRegistry = (logger: TkmLogger): SchemaRegistry => {
 
       schemas.set(name, provider)
     },
+
+    getProvider,
 
     initParameterSchema: async (
       ctx: CommandContext,


### PR DESCRIPTION
… for deployment targets

affects: @takomo/aws-model, @takomo/config-repository-fs, @takomo/deployment-targets-commands,
@takomo/deployment-targets-config, @takomo/deployment-targets-model, @takomo/stacks-model

ISSUES CLOSED: #188