### PR TITLE
feat(deployment targets): add feature flags to disable undeploy and tear down commands

### DIFF
--- a/integration-tests/deployment-targets/configs/feature-flags/disable-teardown/deployment/targets.yml
+++ b/integration-tests/deployment-targets/configs/feature-flags/disable-teardown/deployment/targets.yml
@@ -1,0 +1,2 @@
+deploymentGroups:
+  root: {}

--- a/integration-tests/deployment-targets/configs/feature-flags/disable-teardown/takomo.yml
+++ b/integration-tests/deployment-targets/configs/feature-flags/disable-teardown/takomo.yml
@@ -1,0 +1,2 @@
+features:
+  deploymentTargetsTearDown: false

--- a/integration-tests/deployment-targets/configs/feature-flags/disable-undeploy/deployment/targets.yml
+++ b/integration-tests/deployment-targets/configs/feature-flags/disable-undeploy/deployment/targets.yml
@@ -1,0 +1,2 @@
+deploymentGroups:
+  root: {}

--- a/integration-tests/deployment-targets/configs/feature-flags/disable-undeploy/takomo.yml
+++ b/integration-tests/deployment-targets/configs/feature-flags/disable-undeploy/takomo.yml
@@ -1,0 +1,2 @@
+features:
+  deploymentTargetsUndeploy: false

--- a/integration-tests/deployment-targets/package.json
+++ b/integration-tests/deployment-targets/package.json
@@ -20,7 +20,8 @@
     "integration-test": "jest test --passWithNoTests --runInBand --ci --verbose"
   },
   "dependencies": {
-    "@takomo/test-integration": "3.7.0"
+    "@takomo/test-integration": "3.7.0",
+    "@takomo/core": "3.7.0"
   },
   "devDependencies": {
     "dotenv": "8.2.0",

--- a/integration-tests/deployment-targets/test/feature-flags.test.ts
+++ b/integration-tests/deployment-targets/test/feature-flags.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Test feature flags.
+ */
+
+import { FeatureDisabledError } from "@takomo/core"
+import {
+  executeTeardownTargetsCommand,
+  executeUndeployTargetsCommand,
+} from "@takomo/test-integration"
+
+describe("Feature flags", () => {
+  test("Undeploy fails when undeploy feature flag is set to false", async () => {
+    await executeUndeployTargetsCommand({
+      projectDir: "configs/feature-flags/disable-undeploy",
+    }).expectCommandToThrow(
+      new FeatureDisabledError("deploymentTargetsUndeploy"),
+    )
+  })
+
+  test("Undeploy succeeds when undeploy feature flag is enabled from command line", async () => {
+    await executeUndeployTargetsCommand({
+      projectDir: "configs/feature-flags/disable-undeploy",
+      feature: ["deploymentTargetsUndeploy=true"],
+    })
+      .expectCommandToSkip()
+      .assert()
+  })
+
+  test("Tear down fails when tear down feature flag is set to false", async () => {
+    await executeTeardownTargetsCommand({
+      projectDir: "configs/feature-flags/disable-teardown",
+    }).expectCommandToThrow(
+      new FeatureDisabledError("deploymentTargetsTearDown"),
+    )
+  })
+
+  test("Tear down fails when tear down feature flag is enabled from command line", async () => {
+    await executeTeardownTargetsCommand({
+      projectDir: "configs/feature-flags/disable-teardown",
+      feature: ["deploymentTargetsTearDown=true"],
+    })
+      .expectCommandToSkip()
+      .assert()
+  })
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,9 @@
     "semver": "7.3.4",
     "yargs": "13.3.0"
   },
+  "devDependencies": {
+    "@takomo/test-unit": "3.6.0"
+  },
   "engines": {
     "node": ">=14.4.0"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -73,6 +73,11 @@ export const run = (): void => {
       string: true,
       global: true,
     })
+    .option("feature", {
+      description: "Feature flag",
+      string: true,
+      global: true,
+    })
     .demandCommand(1, "Provide command")
     .strict(true)
     .help().argv

--- a/packages/cli/test/parse-features-from-args.test.ts
+++ b/packages/cli/test/parse-features-from-args.test.ts
@@ -1,0 +1,26 @@
+import { Features } from "@takomo/core"
+import { parseFeaturesFromArgs } from "../src/common"
+
+const cases: Array<[any, Partial<Features>]> = [
+  [undefined, {}],
+  [null, {}],
+  [[], {}],
+  ["deploymentTargetsUndeploy=true", { deploymentTargetsUndeploy: true }],
+  ["deploymentTargetsUndeploy=false", { deploymentTargetsUndeploy: false }],
+  ["deploymentTargetsTearDown=true", { deploymentTargetsTearDown: true }],
+  ["deploymentTargetsTearDown=false", { deploymentTargetsTearDown: false }],
+  [["deploymentTargetsTearDown=false"], { deploymentTargetsTearDown: false }],
+  [
+    ["deploymentTargetsTearDown=true", "deploymentTargetsUndeploy=true"],
+    {
+      deploymentTargetsTearDown: true,
+      deploymentTargetsUndeploy: true,
+    },
+  ],
+]
+
+describe("parseFeaturesFromArgs", () => {
+  test.each(cases)("%#", (given, expected) => {
+    expect(parseFeaturesFromArgs(given)).toStrictEqual(expected)
+  })
+})

--- a/packages/cli/test/parse-features.test.ts
+++ b/packages/cli/test/parse-features.test.ts
@@ -1,0 +1,56 @@
+import { Features } from "@takomo/core"
+import { parseFeatures } from "../src/config"
+
+const cases: Array<[any, Features]> = [
+  [
+    {},
+    {
+      deploymentTargetsUndeploy: true,
+      deploymentTargetsTearDown: true,
+    },
+  ],
+  [
+    null,
+    {
+      deploymentTargetsUndeploy: true,
+      deploymentTargetsTearDown: true,
+    },
+  ],
+  [
+    undefined,
+    {
+      deploymentTargetsUndeploy: true,
+      deploymentTargetsTearDown: true,
+    },
+  ],
+  [
+    { deploymentTargetsUndeploy: false },
+    {
+      deploymentTargetsUndeploy: false,
+      deploymentTargetsTearDown: true,
+    },
+  ],
+  [
+    { deploymentTargetsUndeploy: true },
+    {
+      deploymentTargetsUndeploy: true,
+      deploymentTargetsTearDown: true,
+    },
+  ],
+  [
+    {
+      deploymentTargetsUndeploy: false,
+      deploymentTargetsTearDown: false,
+    },
+    {
+      deploymentTargetsUndeploy: false,
+      deploymentTargetsTearDown: false,
+    },
+  ],
+]
+
+describe("#parseFeatures", () => {
+  test.each(cases)("%#", (given, expected) => {
+    expect(parseFeatures(given)).toStrictEqual(expected)
+  })
+})

--- a/packages/cli/test/parse-project-config-file.test.ts
+++ b/packages/cli/test/parse-project-config-file.test.ts
@@ -1,9 +1,10 @@
+import { defaultFeatures } from "@takomo/core"
 import { FilePath } from "@takomo/util"
 import { parseProjectConfigFile } from "../src/config"
 import { DEFAULT_REGIONS } from "../src/constants"
 
 const doParseProjectConfigFile = (pathToFile: FilePath): any =>
-  parseProjectConfigFile(`${process.cwd()}/test/${pathToFile}`)
+  parseProjectConfigFile(`${process.cwd()}/test/${pathToFile}`, {})
 
 describe("#parseProjectConfigFile", () => {
   test("with empty file", async () => {
@@ -14,6 +15,7 @@ describe("#parseProjectConfigFile", () => {
       deploymentTargets: undefined,
       regions: DEFAULT_REGIONS,
       resolvers: [],
+      features: defaultFeatures(),
     })
   })
 
@@ -25,6 +27,7 @@ describe("#parseProjectConfigFile", () => {
       deploymentTargets: undefined,
       regions: ["eu-west-1"],
       resolvers: [],
+      features: defaultFeatures(),
     })
   })
 
@@ -36,6 +39,7 @@ describe("#parseProjectConfigFile", () => {
       deploymentTargets: undefined,
       regions: ["eu-central-1", "eu-north-1", "us-east-1"],
       resolvers: [],
+      features: defaultFeatures(),
     })
   })
 
@@ -46,6 +50,7 @@ describe("#parseProjectConfigFile", () => {
       organization: undefined,
       deploymentTargets: undefined,
       regions: ["eu-central-1", "us-east-1"],
+      features: defaultFeatures(),
       resolvers: [
         {
           package: "@takomo/my-example-resolver",

--- a/packages/cli/test/takomo-project-config-file-schema.test.ts
+++ b/packages/cli/test/takomo-project-config-file-schema.test.ts
@@ -1,0 +1,20 @@
+import { expectNoValidationError } from "@takomo/test-unit"
+import { takomoProjectConfigFileSchema } from "../src/config"
+
+const valid = [
+  {},
+  { requiredVersion: "1.0.0" },
+  { regions: ["eu-west-1"] },
+  { features: { deploymentTargetsUndeploy: true } },
+  {
+    regions: ["eu-central-1"],
+    features: { deploymentTargetsUndeploy: false },
+  },
+]
+
+describe("project config schema validation", () => {
+  test.each(valid)(
+    "success %#",
+    expectNoValidationError(takomoProjectConfigFileSchema),
+  )
+})

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -58,6 +58,28 @@ export interface TakomoProjectDeploymentTargetsConfig {
 }
 
 /**
+ * Feature flags.
+ */
+export interface Features {
+  /**
+   * Enable deployment targets undeploy command
+   */
+  readonly deploymentTargetsUndeploy: boolean
+  /**
+   * Enable deployment targets tear down command
+   */
+  readonly deploymentTargetsTearDown: boolean
+}
+
+/**
+ * @hidden
+ */
+export const defaultFeatures = (): Features => ({
+  deploymentTargetsUndeploy: true,
+  deploymentTargetsTearDown: true,
+})
+
+/**
  * Takomo project configuration.
  */
 export interface TakomoProjectConfig {
@@ -80,4 +102,21 @@ export interface ExternalResolverConfig {
  */
 export interface InternalTakomoProjectConfig extends TakomoProjectConfig {
   readonly resolvers: ReadonlyArray<ExternalResolverConfig>
+  readonly features: Features
+}
+
+/**
+ * @hidden
+ */
+export class FeatureDisabledError extends TakomoError {
+  constructor(featureName: keyof Features) {
+    super(
+      `Can't execute operation because feature '${featureName}' is not enabled`,
+      {
+        instructions: [
+          `To enable this operation, set features.${featureName} = true in the project configuration`,
+        ],
+      },
+    )
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,9 +21,12 @@ export {
 export {
   AccountRepositoryConfig,
   AccountRepositoryType,
+  defaultFeatures,
   DeploymentTargetRepositoryConfig,
   DeploymentTargetRepositoryType,
   ExternalResolverConfig,
+  FeatureDisabledError,
+  Features,
   InternalTakomoProjectConfig,
   parseCommandRole,
   parseRegex,

--- a/packages/test-integration/src/assertions/targets.ts
+++ b/packages/test-integration/src/assertions/targets.ts
@@ -2,6 +2,8 @@ import { DeploymentTargetsOperationOutput } from "@takomo/deployment-targets-com
 
 export interface TargetsOperationOutputMatcher {
   expectCommandToSucceed: () => TargetsOperationOutputMatcher
+  expectCommandToSkip: () => TargetsOperationOutputMatcher
+  expectCommandToThrow: (error: any) => Promise<void>
   assert: () => Promise<DeploymentTargetsOperationOutput>
 }
 
@@ -17,6 +19,18 @@ export const createTargetsOperationOutputMatcher = (
       expect(output.error).toBeUndefined()
     })
 
+  const expectCommandToSkip = () =>
+    createTargetsOperationOutputMatcher(executor, (output) => {
+      expect(output.status).toEqual("SKIPPED")
+      expect(output.message).toEqual("No targets to deploy")
+      expect(output.success).toEqual(true)
+      expect(output.error).toBeUndefined()
+    })
+
+  const expectCommandToThrow = async (error: any): Promise<void> => {
+    await expect(executor).rejects.toEqual(error)
+  }
+
   const assert = async (): Promise<DeploymentTargetsOperationOutput> => {
     const output = await executor()
     if (outputAssertions) {
@@ -28,6 +42,8 @@ export const createTargetsOperationOutputMatcher = (
 
   return {
     expectCommandToSucceed,
+    expectCommandToSkip,
+    expectCommandToThrow,
     assert,
   }
 }

--- a/packages/test-integration/src/commands/common.ts
+++ b/packages/test-integration/src/commands/common.ts
@@ -12,6 +12,7 @@ export interface ExecuteCommandProps {
   readonly ignoreDependencies?: boolean
   readonly commandPath?: CommandPath
   readonly logLevel?: LogLevel
+  readonly feature?: string[]
 }
 
 export const createTestCommandContext = async (
@@ -35,6 +36,7 @@ export const createTestCommandContext = async (
       log: props.logLevel,
       yes: props.autoConfirmEnabled,
       "ignore-dependencies": props.ignoreDependencies,
+      feature: props.feature,
     },
     credentials,
   )

--- a/packages/test-integration/src/commands/init.ts
+++ b/packages/test-integration/src/commands/init.ts
@@ -63,6 +63,7 @@ export const executeInitProjectCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 

--- a/packages/test-integration/src/commands/organization.ts
+++ b/packages/test-integration/src/commands/organization.ts
@@ -98,6 +98,7 @@ export const executeCreateAccountAliasCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -138,6 +139,7 @@ export const executeDeleteAccountAliasCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -173,6 +175,7 @@ export const executeDescribeOrganizationCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -211,6 +214,7 @@ export const executeCreateOrganizationCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -246,6 +250,7 @@ export const executeListAccountsCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -286,6 +291,7 @@ export const executeDeployAccountsCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -324,6 +330,7 @@ export const executeUndeployAccountsCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -362,6 +369,7 @@ export const executeBootstrapAccountsCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -400,6 +408,7 @@ export const executeTeardownAccountsCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -438,6 +447,7 @@ export const executeDeployOrganizationCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 

--- a/packages/test-integration/src/commands/stacks.ts
+++ b/packages/test-integration/src/commands/stacks.ts
@@ -37,6 +37,7 @@ export interface CreateCtxAndConfigRepositoryProps {
   readonly autoConfirmEnabled: boolean
   readonly ignoreDependencies: boolean
   readonly logLevel: LogLevel
+  readonly feature: ReadonlyArray<string>
 }
 
 export interface CreateTestStacksConfigRepositoryProps {
@@ -95,6 +96,7 @@ export const executeDeployStacksCommand = (
       autoConfirmEnabled: props.autoConfirmEnabled ?? true,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
     })
 
     const logger = createConsoleLogger({
@@ -131,6 +133,7 @@ export const executeUndeployStacksCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -172,6 +175,7 @@ export const executeListStacksCommand = (
       ignoreDependencies: props.ignoreDependencies ?? false,
       var: props.var ?? [],
       varFile: props.varFile ?? [],
+      feature: props.feature ?? [],
       logLevel,
     })
 

--- a/packages/test-integration/src/commands/targets.ts
+++ b/packages/test-integration/src/commands/targets.ts
@@ -81,6 +81,7 @@ export const executeDeployTargetsCommand = (
       var: props.var ?? [],
       varFile: props.varFile ?? [],
       pathToDeploymentConfigFile: props.configFile,
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -120,6 +121,7 @@ export const executeUndeployTargetsCommand = (
       var: props.var ?? [],
       varFile: props.varFile ?? [],
       pathToDeploymentConfigFile: props.configFile,
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -159,6 +161,7 @@ export const executeBootstrapTargetsCommand = (
       var: props.var ?? [],
       varFile: props.varFile ?? [],
       pathToDeploymentConfigFile: props.configFile,
+      feature: props.feature ?? [],
       logLevel,
     })
 
@@ -198,6 +201,7 @@ export const executeTeardownTargetsCommand = (
       var: props.var ?? [],
       varFile: props.varFile ?? [],
       pathToDeploymentConfigFile: props.configFile,
+      feature: props.feature ?? [],
       logLevel,
     })
 


### PR DESCRIPTION
affects: integration-test-deployment-targets, @takomo/cli, @takomo/core,
@takomo/deployment-targets-commands, @takomo/test-integration

ISSUES CLOSED: #196