### PR TITLE
feat(deployment targets): allow wildcards in deployment target names

### DIFF
--- a/integration-tests/deployment-targets/configs/target-name-wildcards/deployment/targets.yml
+++ b/integration-tests/deployment-targets/configs/target-name-wildcards/deployment/targets.yml
@@ -1,0 +1,25 @@
+vars:
+  accountId: "{{ var.ACCOUNT_1_ID }}"
+
+deploymentGroups:
+  applications:
+    configSets: myConfigs
+    targets:
+      - name: hello
+        vars:
+          name: one
+      - name: hello-world
+        vars:
+          name: two
+      - name: say-hello
+        vars:
+          name: three
+      - name: say-hello-world
+        vars:
+          name: four
+
+configSets:
+  myConfigs:
+    description: Logging configs
+    commandPaths:
+      - /

--- a/integration-tests/deployment-targets/configs/target-name-wildcards/stacks/logs.yml
+++ b/integration-tests/deployment-targets/configs/target-name-wildcards/stacks/logs.yml
@@ -1,0 +1,3 @@
+name: {{ var.name }}
+regions: eu-west-1
+commandRole: arn:aws:iam::{{ var.accountId }}:role/OrganizationAccountAccessRole

--- a/integration-tests/deployment-targets/configs/target-name-wildcards/templates/logs.yml
+++ b/integration-tests/deployment-targets/configs/target-name-wildcards/templates/logs.yml
@@ -1,0 +1,3 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/deployment-targets/test/target-name-wildcards.test.ts
+++ b/integration-tests/deployment-targets/test/target-name-wildcards.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Test selecting deployment targets with wildcards.
+ */
+
+import { executeDeployTargetsCommand } from "@takomo/test-integration"
+
+const projectDir = "configs/target-name-wildcards"
+
+describe("Target name wildcards", () => {
+  test("With no wildcard", async () => {
+    const { results } = await executeDeployTargetsCommand({
+      projectDir,
+      targets: ["hello"],
+    })
+      .expectCommandToSucceed()
+      .assert()
+
+    expect(results).toHaveLength(1)
+    expect(results[0].results).toHaveLength(1)
+    expect(results[0].results[0].name).toStrictEqual("hello")
+  })
+
+  test("With starting wildcard", async () => {
+    const { results } = await executeDeployTargetsCommand({
+      projectDir,
+      targets: ["*hello"],
+    })
+      .expectCommandToSucceed()
+      .assert()
+
+    expect(results).toHaveLength(1)
+    expect(results[0].results).toHaveLength(2)
+    expect(results[0].results[0].name).toStrictEqual("hello")
+    expect(results[0].results[1].name).toStrictEqual("say-hello")
+  })
+
+  test("With ending wildcard", async () => {
+    const { results } = await executeDeployTargetsCommand({
+      projectDir,
+      targets: ["hello*"],
+    })
+      .expectCommandToSucceed()
+      .assert()
+
+    expect(results).toHaveLength(1)
+    expect(results[0].results).toHaveLength(2)
+    expect(results[0].results[0].name).toStrictEqual("hello")
+    expect(results[0].results[1].name).toStrictEqual("hello-world")
+  })
+
+  test("With starting and ending wildcard", async () => {
+    const { results } = await executeDeployTargetsCommand({
+      projectDir,
+      targets: ["*hello*"],
+    })
+      .expectCommandToSucceed()
+      .assert()
+
+    expect(results).toHaveLength(1)
+    expect(results[0].results).toHaveLength(4)
+    expect(results[0].results[0].name).toStrictEqual("hello")
+    expect(results[0].results[1].name).toStrictEqual("hello-world")
+    expect(results[0].results[2].name).toStrictEqual("say-hello")
+    expect(results[0].results[3].name).toStrictEqual("say-hello-world")
+  })
+})

--- a/packages/deployment-targets-commands/src/operation/command.ts
+++ b/packages/deployment-targets-commands/src/operation/command.ts
@@ -21,11 +21,11 @@ import { planDeployment } from "./plan"
 const inputSchema = (regions: ReadonlyArray<Region>) => {
   const {
     deploymentGroupPath,
-    deploymentTargetName,
+    deploymentTargetNamePattern,
   } = createDeploymentTargetsSchemas({ regions })
   return Joi.object({
     groups: Joi.array().items(deploymentGroupPath).unique(),
-    targets: Joi.array().items(deploymentTargetName).unique(),
+    targets: Joi.array().items(deploymentTargetNamePattern).unique(),
     concurrentTargets: Joi.number().min(1).max(50),
   }).unknown(true)
 }

--- a/packages/deployment-targets-commands/src/operation/model.ts
+++ b/packages/deployment-targets-commands/src/operation/model.ts
@@ -10,6 +10,7 @@ import { DeploymentTargetsContext } from "@takomo/deployment-targets-context"
 import {
   DeploymentGroupPath,
   DeploymentTargetName,
+  DeploymentTargetNamePattern,
 } from "@takomo/deployment-targets-model"
 import { DeployStacksIO, UndeployStacksIO } from "@takomo/stacks-commands"
 import { DeploymentOperation } from "@takomo/stacks-model"
@@ -27,7 +28,7 @@ export interface TargetsExecutionPlan {
 
 export interface DeploymentTargetsOperationInput extends CommandInput {
   readonly groups: ReadonlyArray<DeploymentGroupPath>
-  readonly targets: ReadonlyArray<DeploymentTargetName>
+  readonly targets: ReadonlyArray<DeploymentTargetNamePattern>
   readonly operation: DeploymentOperation
   readonly configSetType: ConfigSetType
   readonly concurrentTargets: number

--- a/packages/deployment-targets-commands/test/create-deployment-target-name-pattern-matcher.test.ts
+++ b/packages/deployment-targets-commands/test/create-deployment-target-name-pattern-matcher.test.ts
@@ -1,0 +1,38 @@
+import { DeploymentTargetConfig } from "@takomo/deployment-targets-config"
+import { DeploymentTargetName } from "@takomo/deployment-targets-model"
+import { mock } from "jest-mock-extended"
+import { createDeploymentTargetNamePatternMatcher } from "../src/operation/plan"
+
+const target = (name: DeploymentTargetName): DeploymentTargetConfig =>
+  mock<DeploymentTargetConfig>({ name })
+
+describe("#createDeploymentTargetNamePatternMatcher", () => {
+  test("Without wildcard", () => {
+    const m = createDeploymentTargetNamePatternMatcher("hello")
+    expect(m(target("hello"))).toStrictEqual(true)
+    expect(m(target("wellhello"))).toStrictEqual(false)
+    expect(m(target("helloworld"))).toStrictEqual(false)
+    expect(m(target("wellhelloworld"))).toStrictEqual(false)
+  })
+  test("With ending wildcard", () => {
+    const m = createDeploymentTargetNamePatternMatcher("hello*")
+    expect(m(target("hello"))).toStrictEqual(true)
+    expect(m(target("wellhello"))).toStrictEqual(false)
+    expect(m(target("helloworld"))).toStrictEqual(true)
+    expect(m(target("wellhelloworld"))).toStrictEqual(false)
+  })
+  test("With starting wildcard", () => {
+    const m = createDeploymentTargetNamePatternMatcher("*hello")
+    expect(m(target("hello"))).toStrictEqual(true)
+    expect(m(target("wellhello"))).toStrictEqual(true)
+    expect(m(target("helloworld"))).toStrictEqual(false)
+    expect(m(target("wellhelloworld"))).toStrictEqual(false)
+  })
+  test("With ending and starting wildcards", () => {
+    const m = createDeploymentTargetNamePatternMatcher("*hello*")
+    expect(m(target("hello"))).toStrictEqual(true)
+    expect(m(target("wellhello"))).toStrictEqual(true)
+    expect(m(target("helloworld"))).toStrictEqual(true)
+    expect(m(target("wellhelloworld"))).toStrictEqual(true)
+  })
+})

--- a/packages/deployment-targets-model/src/index.ts
+++ b/packages/deployment-targets-model/src/index.ts
@@ -10,6 +10,7 @@ import Joi, { AnySchema } from "joi"
 
 export type DeploymentGroupName = string
 export type DeploymentTargetName = string
+export type DeploymentTargetNamePattern = string
 export type DeploymentGroupPath = string
 export type DeploymentStatus = "active" | "disabled"
 

--- a/packages/deployment-targets-schema/src/index.ts
+++ b/packages/deployment-targets-schema/src/index.ts
@@ -6,6 +6,7 @@ import Joi, { ObjectSchema, StringSchema } from "joi"
 
 export interface DeploymentTargetsSchemas {
   readonly deploymentTargetName: StringSchema
+  readonly deploymentTargetNamePattern: StringSchema
   readonly deploymentGroupPath: StringSchema
   readonly deploymentTarget: ObjectSchema
 }
@@ -65,6 +66,11 @@ export const createDeploymentTargetsSchemas = (
     .max(60)
     .regex(/^[a-zA-Z_]+[a-zA-Z0-9-_]*$/)
 
+  const deploymentTargetNamePattern = Joi.string()
+    .min(1)
+    .max(60)
+    .regex(/^\*?[a-zA-Z_]+[a-zA-Z0-9-_]*\*?$/)
+
   const deploymentTarget = Joi.object({
     vars,
     accountId,
@@ -84,6 +90,7 @@ export const createDeploymentTargetsSchemas = (
 
   return {
     deploymentTargetName,
+    deploymentTargetNamePattern,
     deploymentGroupPath,
     deploymentTarget,
   }

--- a/packages/deployment-targets-schema/test/deployment-target-name-pattern.test.ts
+++ b/packages/deployment-targets-schema/test/deployment-target-name-pattern.test.ts
@@ -1,0 +1,43 @@
+import {
+  expectNoValidationError,
+  expectValidationErrors,
+} from "@takomo/test-unit"
+import { createDeploymentTargetsSchemas } from "../src"
+
+const { deploymentTargetNamePattern } = createDeploymentTargetsSchemas({
+  regions: ["eu-west-1"],
+})
+
+const valid = [
+  "MyTarget",
+  "deployment-target",
+  "target1",
+  "_targetA",
+  "MY_TARGET",
+  "x".repeat(60),
+  "target1*",
+  "*target1",
+  "*target1*",
+]
+const invalid = [
+  ["", '"value" is not allowed to be empty'],
+  [
+    "no spaces",
+    '"value" with value "no spaces" fails to match the required pattern: /^\\*?[a-zA-Z_]+[a-zA-Z0-9-_]*\\*?$/',
+  ],
+  [
+    "x".repeat(61),
+    '"value" length must be less than or equal to 60 characters long',
+  ],
+]
+
+describe("deployment target name pattern validation", () => {
+  test.each(valid)(
+    "succeeds when '%s' is given",
+    expectNoValidationError(deploymentTargetNamePattern),
+  )
+  test.each(invalid)(
+    "fails when '%s' is given",
+    expectValidationErrors(deploymentTargetNamePattern),
+  )
+})


### PR DESCRIPTION
affects: integration-test-deployment-targets, @takomo/deployment-targets-commands,
@takomo/deployment-targets-model, @takomo/deployment-targets-schema

ISSUES CLOSED: #205