### PR TITLE
feat(organizations): add support to deploy accounts in parallel

### DIFF
--- a/integration-tests/organization2/configs/simple/config-sets/hello/example.yml
+++ b/integration-tests/organization2/configs/simple/config-sets/hello/example.yml
@@ -1,0 +1,2 @@
+template: example.yml
+regions: eu-west-1

--- a/integration-tests/organization2/configs/simple/organization/organization.yml
+++ b/integration-tests/organization2/configs/simple/organization/organization.yml
@@ -4,6 +4,7 @@ organizationalUnits:
     accounts:
       - "{{ env.TKM_ORG_3_MASTER_ACCOUNT_ID }}"
   Root/Test:
+    configSets: hello
     accounts:
       - "{{ env.TKM_ORG_3_ACCOUNT_01_ID }}"
       - "{{ env.TKM_ORG_3_ACCOUNT_02_ID }}"

--- a/integration-tests/organization2/configs/simple/templates/example.yml
+++ b/integration-tests/organization2/configs/simple/templates/example.yml
@@ -1,0 +1,3 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/organization2/test/concurrent-accounts.test.ts
+++ b/integration-tests/organization2/test/concurrent-accounts.test.ts
@@ -1,0 +1,74 @@
+import {
+  executeDeployAccountsCommand,
+  executeUndeployAccountsCommand,
+} from "@takomo/test-integration"
+import {
+  ORG_3_ACCOUNT_01_ID,
+  ORG_3_ACCOUNT_02_ID,
+  ORG_3_ACCOUNT_03_ID,
+} from "./env"
+
+const projectDir = "configs/simple"
+const configSetResults = [
+  {
+    configSet: "hello",
+    commandPathResults: [
+      {
+        commandPath: "/",
+        stackResults: [
+          {
+            stackPath: "/example.yml/eu-west-1",
+            stackName: "example",
+          },
+        ],
+      },
+    ],
+  },
+]
+
+describe("concurrent accounts", () => {
+  test("Deploy", () =>
+    executeDeployAccountsCommand({ projectDir, concurrentAccounts: 4 })
+      .expectCommandToSucceed()
+      .expectResults({
+        organizationalUnitPath: "Root/Test",
+        unorderedAccounts: true,
+        accountResults: [
+          {
+            accountId: ORG_3_ACCOUNT_01_ID,
+            configSetResults,
+          },
+          {
+            accountId: ORG_3_ACCOUNT_02_ID,
+            configSetResults,
+          },
+          {
+            accountId: ORG_3_ACCOUNT_03_ID,
+            configSetResults,
+          },
+        ],
+      })
+      .assert())
+  test("Undeploy", () =>
+    executeUndeployAccountsCommand({ projectDir, concurrentAccounts: 2 })
+      .expectCommandToSucceed()
+      .expectResults({
+        organizationalUnitPath: "Root/Test",
+        unorderedAccounts: true,
+        accountResults: [
+          {
+            accountId: ORG_3_ACCOUNT_01_ID,
+            configSetResults,
+          },
+          {
+            accountId: ORG_3_ACCOUNT_02_ID,
+            configSetResults,
+          },
+          {
+            accountId: ORG_3_ACCOUNT_03_ID,
+            configSetResults,
+          },
+        ],
+      })
+      .assert())
+})

--- a/packages/cli/src/organization/accounts/bootstrap.ts
+++ b/packages/cli/src/organization/accounts/bootstrap.ts
@@ -15,6 +15,13 @@ export const bootstrapAccountsCmd = {
   builder: (yargs: any) =>
     yargs
       .epilog(commonEpilog(accountsDeployOperationCommandIamPolicy))
+      .option("concurrent-accounts", {
+        description: "Number of accounts to bootstrap concurrently",
+        number: true,
+        global: false,
+        demandOption: false,
+        default: 1,
+      })
       .option("account-id", {
         description: "Account id to bootstrap",
         alias: "a",
@@ -29,6 +36,7 @@ export const bootstrapAccountsCmd = {
         ...input,
         organizationalUnits: argv.organizationalUnits || [],
         accountIds: parseAccountIds(argv["account-id"]),
+        concurrentAccounts: argv["concurrent-accounts"],
         operation: "deploy" as DeploymentOperation,
         configSetType: "bootstrap" as ConfigSetType,
       }),

--- a/packages/cli/src/organization/accounts/deploy.ts
+++ b/packages/cli/src/organization/accounts/deploy.ts
@@ -15,6 +15,13 @@ export const deployAccountsCmd = {
   builder: (yargs: any) =>
     yargs
       .epilog(commonEpilog(accountsDeployOperationCommandIamPolicy))
+      .option("concurrent-accounts", {
+        description: "Number of accounts to deploy concurrently",
+        number: true,
+        global: false,
+        demandOption: false,
+        default: 1,
+      })
       .option("account-id", {
         description: "Account id to deploy",
         alias: "a",
@@ -29,6 +36,7 @@ export const deployAccountsCmd = {
         ...input,
         organizationalUnits: argv.organizationalUnits || [],
         accountIds: parseAccountIds(argv["account-id"]),
+        concurrentAccounts: argv["concurrent-accounts"],
         operation: "deploy" as DeploymentOperation,
         configSetType: "standard" as ConfigSetType,
       }),

--- a/packages/cli/src/organization/accounts/tear-down.ts
+++ b/packages/cli/src/organization/accounts/tear-down.ts
@@ -15,6 +15,13 @@ export const tearDownAccountsCmd = {
   builder: (yargs: any) =>
     yargs
       .epilog(commonEpilog(accountsUndeployOperationCommandIamPolicy))
+      .option("concurrent-accounts", {
+        description: "Number of accounts to tear down concurrently",
+        number: true,
+        global: false,
+        demandOption: false,
+        default: 1,
+      })
       .option("account-id", {
         description: "Account id to tear down",
         alias: "a",
@@ -29,6 +36,7 @@ export const tearDownAccountsCmd = {
         ...input,
         organizationalUnits: argv.organizationalUnits || [],
         accountIds: parseAccountIds(argv["account-id"]),
+        concurrentAccounts: argv["concurrent-accounts"],
         operation: "undeploy" as DeploymentOperation,
         configSetType: "bootstrap" as ConfigSetType,
       }),

--- a/packages/cli/src/organization/accounts/undeploy.ts
+++ b/packages/cli/src/organization/accounts/undeploy.ts
@@ -15,6 +15,13 @@ export const undeployAccountsCmd = {
   builder: (yargs: any) =>
     yargs
       .epilog(commonEpilog(accountsUndeployOperationCommandIamPolicy))
+      .option("concurrent-accounts", {
+        description: "Number of accounts to undeploy concurrently",
+        number: true,
+        global: false,
+        demandOption: false,
+        default: 1,
+      })
       .option("account-id", {
         description: "Account id to undeploy",
         alias: "a",
@@ -29,6 +36,7 @@ export const undeployAccountsCmd = {
         ...input,
         organizationalUnits: argv.organizationalUnits || [],
         accountIds: parseAccountIds(argv["account-id"]),
+        concurrentAccounts: argv["concurrent-accounts"],
         operation: "undeploy" as DeploymentOperation,
         configSetType: "standard" as ConfigSetType,
       }),

--- a/packages/deployment-targets-commands/src/index.ts
+++ b/packages/deployment-targets-commands/src/index.ts
@@ -5,6 +5,7 @@ export {
 } from "./operation/iam-policy"
 export {
   ConfirmOperationAnswer,
+  DeploymentGroupDeployResult,
   DeploymentTargetsListener,
   DeploymentTargetsOperationInput,
   DeploymentTargetsOperationIO,

--- a/packages/organization-commands/src/accounts/operation/execute/organizational-units.ts
+++ b/packages/organization-commands/src/accounts/operation/execute/organizational-units.ts
@@ -2,29 +2,44 @@ import { ConfigSetType } from "@takomo/config-sets"
 import { resolveCommandOutputBase } from "@takomo/core"
 import { OperationState } from "@takomo/stacks-model"
 import { Timer } from "@takomo/util"
+import { IPolicy, Policy } from "cockatiel"
 import {
   AccountOperationResult,
+  AccountsListener,
   OrganizationalUnitAccountsOperationResult,
   PlannedAccountDeploymentOrganizationalUnit,
+  PlannedLaunchableAccount,
 } from "../model"
 import { AccountsOperationPlanHolder } from "../states"
 import { processAccount } from "./account"
 
-export const processOrganizationalUnit = async (
-  holder: AccountsOperationPlanHolder,
-  organizationalUnit: PlannedAccountDeploymentOrganizationalUnit,
-  timer: Timer,
-  state: OperationState,
-  configSetType: ConfigSetType,
-): Promise<OrganizationalUnitAccountsOperationResult> => {
-  const { io } = holder
+type AccountOperation = () => Promise<AccountOperationResult>
 
-  io.info(
-    `Process organizational unit '${organizationalUnit.path}' with ${organizationalUnit.accounts.length} account(s)`,
-  )
+interface ConvertToOperationProps {
+  readonly holder: AccountsOperationPlanHolder
+  readonly organizationalUnit: PlannedAccountDeploymentOrganizationalUnit
+  readonly timer: Timer
+  readonly policy: IPolicy
+  readonly account: PlannedLaunchableAccount
+  readonly state: OperationState
+  readonly configSetType: ConfigSetType
+  readonly results: Array<AccountOperationResult>
+  readonly accountsListener: AccountsListener
+}
 
-  const results = new Array<AccountOperationResult>()
-  for (const account of organizationalUnit.accounts) {
+const convertToOperation = ({
+  holder,
+  organizationalUnit,
+  timer,
+  policy,
+  account,
+  state,
+  configSetType,
+  results,
+  accountsListener,
+}: ConvertToOperationProps): AccountOperation => () =>
+  policy.execute(async () => {
+    await accountsListener.onAccountBegin()
     const result = await processAccount(
       holder,
       organizationalUnit,
@@ -33,8 +48,47 @@ export const processOrganizationalUnit = async (
       state,
       configSetType,
     )
+
     results.push(result)
-  }
+    await accountsListener.onAccountComplete()
+    return result
+  })
+
+export const processOrganizationalUnit = async (
+  holder: AccountsOperationPlanHolder,
+  organizationalUnit: PlannedAccountDeploymentOrganizationalUnit,
+  timer: Timer,
+  state: OperationState,
+  configSetType: ConfigSetType,
+): Promise<OrganizationalUnitAccountsOperationResult> => {
+  const {
+    io,
+    input: { concurrentAccounts },
+    accountsListener,
+  } = holder
+
+  io.info(
+    `Process organizational unit '${organizationalUnit.path}' with ${organizationalUnit.accounts.length} account(s)`,
+  )
+
+  const policy = Policy.bulkhead(concurrentAccounts, 10000)
+  const results = new Array<AccountOperationResult>()
+
+  const operations = organizationalUnit.accounts.map((account) =>
+    convertToOperation({
+      holder,
+      timer,
+      policy,
+      account,
+      configSetType,
+      organizationalUnit,
+      results,
+      state,
+      accountsListener,
+    }),
+  )
+
+  await Promise.all(operations.map((o) => o()))
 
   timer.stop()
   return {

--- a/packages/organization-commands/src/accounts/operation/model.ts
+++ b/packages/organization-commands/src/accounts/operation/model.ts
@@ -18,6 +18,7 @@ export interface AccountsOperationInput extends CommandInput {
   readonly accountIds: ReadonlyArray<AccountId>
   readonly operation: DeploymentOperation
   readonly configSetType: ConfigSetType
+  readonly concurrentAccounts: number
 }
 
 export interface AccountOperationResult extends CommandOutputBase {
@@ -37,10 +38,16 @@ export interface AccountsOperationOutput extends CommandOutput {
   readonly results?: ReadonlyArray<OrganizationalUnitAccountsOperationResult>
 }
 
+export interface AccountsListener {
+  readonly onAccountBegin: () => Promise<void>
+  readonly onAccountComplete: () => Promise<void>
+}
+
 export interface AccountsOperationIO extends IO<AccountsOperationOutput> {
   readonly createStackDeployIO: (accountId: AccountId) => DeployStacksIO
   readonly createStackUndeployIO: (accountId: AccountId) => UndeployStacksIO
   readonly confirmLaunch: (plan: AccountsLaunchPlan) => Promise<ConfirmResult>
+  readonly createAccountsListener: (accountCount: number) => AccountsListener
 }
 
 export interface PlannedLaunchableAccount {

--- a/packages/organization-commands/src/accounts/operation/states.ts
+++ b/packages/organization-commands/src/accounts/operation/states.ts
@@ -10,6 +10,7 @@ import { OrganizationalUnitsDeploymentPlan } from "../../common/plan/organizatio
 import { PolicyDeploymentPlan } from "../../common/plan/policies/model"
 import {
   AccountsLaunchPlan,
+  AccountsListener,
   AccountsOperationInput,
   AccountsOperationIO,
   OrganizationalUnitAccountsOperationResult,
@@ -43,6 +44,7 @@ export interface OrganizationalUnitsPlanHolder extends PoliciesPlanHolder {
 
 export interface AccountsOperationPlanHolder extends OrganizationStateHolder {
   readonly accountsLaunchPlan: AccountsLaunchPlan
+  readonly accountsListener: AccountsListener
 }
 
 export interface AccountsOperationFailedState

--- a/packages/organization-commands/src/index.ts
+++ b/packages/organization-commands/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./accounts/operation/iam-policy"
 export {
   AccountsLaunchPlan,
+  AccountsListener,
   AccountsOperationInput,
   AccountsOperationIO,
   AccountsOperationOutput,

--- a/packages/test-integration/src/assertions/organization.ts
+++ b/packages/test-integration/src/assertions/organization.ts
@@ -213,6 +213,8 @@ export interface ExpectAccountResultProps {
 export interface ExpectOrganizationalUnitResultProps {
   readonly organizationalUnitPath: OrganizationalUnitPath
   readonly accountResults: ReadonlyArray<ExpectAccountResultProps>
+  // Do not require accounts to be in specified order
+  readonly unorderedAccounts?: boolean
 }
 
 export interface AccountsOperationOutputMatcher {
@@ -267,7 +269,19 @@ export const createAccountsOperationOutputMatcher = ({
         expect(result.results).toHaveLength(prop.accountResults.length)
 
         result.results.forEach((accountResult, i) => {
-          const expected = prop.accountResults[i]
+          const expected =
+            prop.unorderedAccounts === true
+              ? prop.accountResults.find(
+                  (a) => a.accountId === accountResult.accountId,
+                )
+              : prop.accountResults[i]
+
+          if (!expected) {
+            fail(
+              `Unexpected account ${accountResult.accountId} found under organizational unit ${result.path}`,
+            )
+          }
+
           expect(accountResult.accountId).toStrictEqual(expected.accountId)
           expect(accountResult.success).toStrictEqual(true)
           if (expected.status) {

--- a/packages/test-integration/src/assertions/targets.ts
+++ b/packages/test-integration/src/assertions/targets.ts
@@ -1,8 +1,10 @@
 import { StackName } from "@takomo/aws-model"
 import { ConfigSetName } from "@takomo/config-sets"
 import { CommandStatus } from "@takomo/core"
-import { DeploymentTargetsOperationOutput } from "@takomo/deployment-targets-commands"
-import { DeploymentGroupDeployResult } from "@takomo/deployment-targets-commands/src/operation/model"
+import {
+  DeploymentGroupDeployResult,
+  DeploymentTargetsOperationOutput,
+} from "@takomo/deployment-targets-commands"
 import {
   DeploymentGroupPath,
   DeploymentTargetName,

--- a/packages/test-integration/src/commands/organization.ts
+++ b/packages/test-integration/src/commands/organization.ts
@@ -287,6 +287,7 @@ export interface ExecuteAccountsOperationCommandProps
   extends ExecuteCommandProps {
   readonly accountIds?: ReadonlyArray<AccountId>
   readonly organizationalUnits?: ReadonlyArray<OrganizationalUnitPath>
+  readonly concurrentAccounts?: number
 }
 
 export const executeDeployAccountsCommand = (
@@ -328,6 +329,7 @@ export const executeDeployAccountsCommand = (
           operation: "deploy",
           accountIds: props.accountIds ?? [],
           organizationalUnits: props.organizationalUnits ?? [],
+          concurrentAccounts: props.concurrentAccounts ?? 1,
         },
       })
     },
@@ -372,6 +374,7 @@ export const executeUndeployAccountsCommand = (
           operation: "undeploy",
           accountIds: props.accountIds ?? [],
           organizationalUnits: props.organizationalUnits ?? [],
+          concurrentAccounts: props.concurrentAccounts ?? 1,
         },
       })
     },
@@ -416,6 +419,7 @@ export const executeBootstrapAccountsCommand = (
           operation: "deploy",
           accountIds: props.accountIds ?? [],
           organizationalUnits: props.organizationalUnits ?? [],
+          concurrentAccounts: props.concurrentAccounts ?? 1,
         },
       })
     },
@@ -460,6 +464,7 @@ export const executeTeardownAccountsCommand = (
           operation: "undeploy",
           accountIds: props.accountIds ?? [],
           organizationalUnits: props.organizationalUnits ?? [],
+          concurrentAccounts: props.concurrentAccounts ?? 1,
         },
       })
     },


### PR DESCRIPTION
affects: integration-test-organization2, @takomo/cli-io, @takomo/cli,
@takomo/deployment-targets-commands, @takomo/organization-commands, @takomo/test-integration

ISSUES CLOSED: #25