### PR TITLE
feat(helpers): add support to load custom Handlebars helpers from NPM…

### DIFF
--- a/integration-tests/stacks/configs/helpers-from-npm/stacks/stack1.yml
+++ b/integration-tests/stacks/configs/helpers-from-npm/stacks/stack1.yml
@@ -1,0 +1,6 @@
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+regions: eu-north-1
+tags:
+  Tag1: {{ to-upper 'one' }}
+  Tag2: {{ lower-case 'TWO' }}
+  Tag3: {{ upper-case 'three' }}

--- a/integration-tests/stacks/configs/helpers-from-npm/takomo.yml
+++ b/integration-tests/stacks/configs/helpers-from-npm/takomo.yml
@@ -1,0 +1,11 @@
+helpers:
+
+  # Just the package name
+  - "@takomo/test-custom-helper-uppercase"
+
+  # Package name in property
+  - package: "@takomo/test-custom-helper-lowercase"
+
+  # Package name in property and overriding name
+  - package: "@takomo/test-custom-helper-uppercase"
+    name: to-upper

--- a/integration-tests/stacks/configs/helpers-from-npm/templates/stack1.yml
+++ b/integration-tests/stacks/configs/helpers-from-npm/templates/stack1.yml
@@ -1,0 +1,3 @@
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/package.json
+++ b/integration-tests/stacks/package.json
@@ -16,7 +16,7 @@
     "clean:dist": "rm -rf dist",
     "clean:deps": "rm -rf node_modules",
     "clean:all": "rm -rf node_modules dist && rm -f yarn.lock",
-    "depcheck": "depcheck --ignores=@babel/core,@babel/preset-env,@babel/preset-typescript,babel-jest,@types/jest,typescript,@takomo/test-custom-resolver-name,@takomo/test-custom-resolver-code",
+    "depcheck": "depcheck --ignores=@babel/core,@babel/preset-env,@babel/preset-typescript,babel-jest,@types/jest,typescript,@takomo/test-custom-resolver-name,@takomo/test-custom-resolver-code,@takomo/test-custom-helper-uppercase,@takomo/test-custom-helper-lowercase",
     "integration-test": "jest test --passWithNoTests --maxWorkers=10 --ci --verbose"
   },
   "dependencies": {
@@ -30,6 +30,8 @@
   "devDependencies": {
     "@takomo/test-custom-resolver-code": "0.0.1",
     "@takomo/test-custom-resolver-name": "0.0.1",
+    "@takomo/test-custom-helper-uppercase": "0.0.1",
+    "@takomo/test-custom-helper-lowercase": "0.0.1",
     "@types/tmp": "^0.2.0",
     "dotenv": "8.2.0",
     "jest-environment-testenv-recycler": "0.0.12"

--- a/integration-tests/stacks/test/helpers-from-npm.test.ts
+++ b/integration-tests/stacks/test/helpers-from-npm.test.ts
@@ -1,0 +1,35 @@
+import {
+  executeDeployStacksCommand,
+  withSingleAccountReservation,
+} from "@takomo/test-integration"
+
+const stackName = "stack1",
+  stackPath = "/stack1.yml/eu-north-1",
+  projectDir = "configs/helpers-from-npm"
+
+describe("Helpers from npm", () => {
+  test(
+    "Deploy",
+    withSingleAccountReservation(({ accountId, credentials }) =>
+      executeDeployStacksCommand({ projectDir })
+        .expectCommandToSucceed()
+        .expectStackCreateSuccess({
+          stackName,
+          stackPath,
+        })
+        .expectDeployedCfStack({
+          stackName,
+          accountId,
+          credentials,
+          region: "eu-north-1",
+          roleName: "OrganizationAccountAccessRole",
+          expectedTags: {
+            Tag1: "ONE",
+            Tag2: "two",
+            Tag3: "THREE",
+          },
+        })
+        .assert(),
+    ),
+  )
+})

--- a/packages/cli/test/parse-project-config-file.test.ts
+++ b/packages/cli/test/parse-project-config-file.test.ts
@@ -15,6 +15,7 @@ describe("#parseProjectConfigFile", () => {
       deploymentTargets: undefined,
       regions: DEFAULT_REGIONS,
       resolvers: [],
+      helpers: [],
       features: defaultFeatures(),
     })
   })
@@ -27,6 +28,7 @@ describe("#parseProjectConfigFile", () => {
       deploymentTargets: undefined,
       regions: ["eu-west-1"],
       resolvers: [],
+      helpers: [],
       features: defaultFeatures(),
     })
   })
@@ -39,6 +41,7 @@ describe("#parseProjectConfigFile", () => {
       deploymentTargets: undefined,
       regions: ["eu-central-1", "eu-north-1", "us-east-1"],
       resolvers: [],
+      helpers: [],
       features: defaultFeatures(),
     })
   })
@@ -50,6 +53,7 @@ describe("#parseProjectConfigFile", () => {
       organization: undefined,
       deploymentTargets: undefined,
       regions: ["eu-central-1", "us-east-1"],
+      helpers: [],
       features: defaultFeatures(),
       resolvers: [
         {
@@ -61,6 +65,31 @@ describe("#parseProjectConfigFile", () => {
         },
         {
           package: "another-resolver-v2",
+          name: "a-better-name",
+        },
+      ],
+    })
+  })
+
+  test("with helpers", async () => {
+    const config = await doParseProjectConfigFile("project-config-05.yml")
+    expect(config).toStrictEqual({
+      requiredVersion: undefined,
+      organization: undefined,
+      deploymentTargets: undefined,
+      regions: ["eu-central-1", "us-east-1"],
+      resolvers: [],
+      features: defaultFeatures(),
+      helpers: [
+        {
+          package: "@takomo/my-example-helper",
+        },
+        {
+          package: "another-helper",
+          name: undefined,
+        },
+        {
+          package: "another-helper-v2",
           name: "a-better-name",
         },
       ],

--- a/packages/cli/test/project-config-05.yml
+++ b/packages/cli/test/project-config-05.yml
@@ -1,0 +1,8 @@
+regions:
+  - eu-central-1
+  - us-east-1
+helpers:
+  - "@takomo/my-example-helper"
+  - package: "another-helper"
+  - package: another-helper-v2
+    name: a-better-name

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -100,8 +100,17 @@ export interface ExternalResolverConfig {
 /**
  * @hidden
  */
+export interface ExternalHandlebarsHelperConfig {
+  readonly name?: string
+  readonly package: string
+}
+
+/**
+ * @hidden
+ */
 export interface InternalTakomoProjectConfig extends TakomoProjectConfig {
   readonly resolvers: ReadonlyArray<ExternalResolverConfig>
+  readonly helpers: ReadonlyArray<ExternalHandlebarsHelperConfig>
   readonly features: Features
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   defaultFeatures,
   DeploymentTargetRepositoryConfig,
   DeploymentTargetRepositoryType,
+  ExternalHandlebarsHelperConfig,
   ExternalResolverConfig,
   FeatureDisabledError,
   Features,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,16 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@takomo/test-custom-helper-lowercase@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@takomo/test-custom-helper-lowercase/-/test-custom-helper-lowercase-0.0.1.tgz#b49dabcfe5d5cc1c749459491283b6a8e666e511"
+  integrity sha512-lXa+O4j/sOmkL/Mi0Qd0rJrwZdzHeOGFj++2m8/jlRAMuXY87mP7VxPs4yrtClXcunCdP61eUXJejBnlFdvXVg==
+
+"@takomo/test-custom-helper-uppercase@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@takomo/test-custom-helper-uppercase/-/test-custom-helper-uppercase-0.0.1.tgz#1d2c4ac011ce4e1b018098b5ff86b31cfaadac41"
+  integrity sha512-8BP/aSLF5xJ6ALRd/kgU7nqgq+E5Bi9fnao9wZhPvTWQ4Bo0p3bPowO9USUhiLn1xFFTEzqm+qafMwDEK/sPng==
+
 "@takomo/test-custom-resolver-code@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@takomo/test-custom-resolver-code/-/test-custom-resolver-code-0.0.1.tgz#9179965f9986df2bec9cc3347956f34529a520b6"


### PR DESCRIPTION
… packages

affects: integration-test-stacks, @takomo/cli, @takomo/config-repository-fs, @takomo/core,
@takomo/test-integration

ISSUES CLOSED: #173