### PR TITLE
perf(stacks): add concurrency controls to stack deployment

### DIFF
--- a/packages/aws-clients/src/aws-client-provider.ts
+++ b/packages/aws-clients/src/aws-client-provider.ts
@@ -53,7 +53,13 @@ const createDescribeEventsBulkhead = (): IPolicy => {
 }
 
 const createGetTemplateSummaryBulkhead = (): IPolicy => {
-  const limit = 2
+  const limit = 1
+  const queue = 1000
+  return Policy.bulkhead(limit, queue)
+}
+
+const createValidateTemplateBulkhead = (): IPolicy => {
+  const limit = 4
   const queue = 1000
   return Policy.bulkhead(limit, queue)
 }
@@ -68,6 +74,7 @@ export const createAwsClientProvider = (
   const regions = new Set<Region>()
   const describeEventsBulkhead = createDescribeEventsBulkhead()
   const getTemplateSummaryBulkhead = createGetTemplateSummaryBulkhead()
+  const validateTemplateBulkhead = createValidateTemplateBulkhead()
 
   const listener = {
     onApiCall: (props: ApiCallProps): void => {
@@ -86,6 +93,7 @@ export const createAwsClientProvider = (
         ...props,
         describeEventsBulkhead,
         getTemplateSummaryBulkhead,
+        validateTemplateBulkhead,
         waitStackDeployToCompletePollInterval: 2000,
         waitStackDeleteToCompletePollInterval: 2000,
       })

--- a/packages/aws-clients/src/cloudformation/client.ts
+++ b/packages/aws-clients/src/cloudformation/client.ts
@@ -173,6 +173,7 @@ const findTerminalEvent = (
 interface CloudFormationClientProps extends AwsClientProps {
   readonly describeEventsBulkhead: IPolicy
   readonly getTemplateSummaryBulkhead: IPolicy
+  readonly validateTemplateBulkhead: IPolicy
   readonly waitStackDeployToCompletePollInterval: number
   readonly waitStackDeleteToCompletePollInterval: number
 }
@@ -199,6 +200,7 @@ export const createCloudFormationClient = (
     logger,
     describeEventsBulkhead,
     getTemplateSummaryBulkhead,
+    validateTemplateBulkhead,
     waitStackDeployToCompletePollInterval,
     waitStackDeleteToCompletePollInterval,
   } = props
@@ -240,7 +242,8 @@ export const createCloudFormationClient = (
   }
 
   const validateTemplate = (input: ValidateTemplateInput): Promise<boolean> =>
-    withClientPromise(
+    withClientPromiseBulkhead(
+      validateTemplateBulkhead,
       (c) => c.validateTemplate(input),
       () => true,
     )

--- a/packages/stacks-commands/package.json
+++ b/packages/stacks-commands/package.json
@@ -37,7 +37,8 @@
     "@takomo/util": "3.29.0",
     "aws-sdk": "2.973.0",
     "joi": "17.4.0",
-    "ramda": "0.27.1"
+    "ramda": "0.27.1",
+    "cockatiel": "2.0.1"
   },
   "engines": {
     "node": ">=14.4.0"

--- a/packages/stacks-context/src/config/build-stacks-context.ts
+++ b/packages/stacks-context/src/config/build-stacks-context.ts
@@ -130,6 +130,7 @@ export const buildStacksContext = async ({
     templateEngine,
     rootStackGroup,
     stacks,
+    concurrentStacks: 20,
     getStackGroup: (stackGroupPath: StackGroupPath) =>
       stackGroups.get(stackGroupPath),
     getStackByExactPath: (path: StackPath, stackGroupPath?: StackGroupPath) => {

--- a/packages/stacks-model/src/context.ts
+++ b/packages/stacks-model/src/context.ts
@@ -43,6 +43,7 @@ export interface StacksContext extends CommandContext {
  * @hidden
  */
 export interface InternalStacksContext extends CommandContext {
+  readonly concurrentStacks: number
   readonly credentialManager: CredentialManager
   readonly templateEngine: TemplateEngine
   readonly rootStackGroup: StackGroup


### PR DESCRIPTION
affects: @takomo/aws-clients, @takomo/stacks-commands, @takomo/stacks-context, @takomo/stacks-model