### PR TITLE
fix(stacks): disable termination protection from failed stacks before…

### DIFF
--- a/integration-tests/stacks/configs/failing-stack/stacks/failure.yml
+++ b/integration-tests/stacks/configs/failing-stack/stacks/failure.yml
@@ -1,4 +1,5 @@
 template: failing-template.yml
+terminationProtection: {{ var.terminationProtection }}
 commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
 regions: eu-west-1
 parameters:

--- a/integration-tests/stacks/test/failing-stack.test.ts
+++ b/integration-tests/stacks/test/failing-stack.test.ts
@@ -11,7 +11,7 @@ describe("Failing stack", () => {
   test("Deploy should fail", () =>
     executeDeployStacksCommand({
       projectDir,
-      var: ["create_wait_condition=true"],
+      var: ["create_wait_condition=true", "terminationProtection=false"],
     })
       .expectCommandToFail("Failed")
       .expectStackCreateFail({
@@ -23,7 +23,7 @@ describe("Failing stack", () => {
   test("Deploying again should succeed when the failing resources are not created", () =>
     executeDeployStacksCommand({
       projectDir,
-      var: ["create_wait_condition=false"],
+      var: ["create_wait_condition=false", "terminationProtection=false"],
     })
       .expectCommandToSucceed()
       .expectStackCreateSuccess({
@@ -35,9 +35,33 @@ describe("Failing stack", () => {
   test("Undeploy", () =>
     executeUndeployStacksCommand({
       projectDir,
-      var: ["create_wait_condition=false"],
+      var: ["create_wait_condition=false", "terminationProtection=false"],
     })
       .expectCommandToSucceed()
       .expectStackDeleteSuccess({ stackName, stackPath })
+      .assert())
+
+  test("Deploy with termination protection should fail", () =>
+    executeDeployStacksCommand({
+      projectDir,
+      var: ["create_wait_condition=true", "terminationProtection=true"],
+    })
+      .expectCommandToFail("Failed")
+      .expectStackCreateFail({
+        stackPath,
+        stackName,
+      })
+      .assert())
+
+  test("Deploying again with termination protection should succeed when the failing resources are not created", () =>
+    executeDeployStacksCommand({
+      projectDir,
+      var: ["create_wait_condition=false", "terminationProtection=false"],
+    })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess({
+        stackName,
+        stackPath,
+      })
       .assert())
 })

--- a/packages/stacks-commands/src/stacks/deploy/steps/initiate-failed-stack-delete.ts
+++ b/packages/stacks-commands/src/stacks/deploy/steps/initiate-failed-stack-delete.ts
@@ -9,9 +9,12 @@ export const initiateFailedStackDelete: StackOperationStep<CurrentStackHolder> =
   async (state) => {
     const { transitions, stack, currentStack } = state
 
+    const client = stack.getCloudFormationClient()
+    await client.updateTerminationProtection(stack.name, false)
+
     const deleteFailedStackClientToken = uuid()
 
-    await stack.getCloudFormationClient().initiateStackDeletion({
+    await client.initiateStackDeletion({
       StackName: stack.name,
       ClientRequestToken: deleteFailedStackClientToken,
     })


### PR DESCRIPTION
… deleting them

affects: integration-test-stacks, @takomo/stacks-commands

ISSUES CLOSED: #293