### PR TITLE
feat(stacks): load helpers from a custom directories

### DIFF
--- a/integration-tests/stacks/configs/helpers-from-custom-dirs/custom-helpers/code.js
+++ b/integration-tests/stacks/configs/helpers-from-custom-dirs/custom-helpers/code.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: "code",
+  fn: () => "CODE",
+}

--- a/integration-tests/stacks/configs/helpers-from-custom-dirs/custom-helpers/other.js
+++ b/integration-tests/stacks/configs/helpers-from-custom-dirs/custom-helpers/other.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: "other",
+  fn: () => "OTHER",
+}

--- a/integration-tests/stacks/configs/helpers-from-custom-dirs/stacks/stack.yml
+++ b/integration-tests/stacks/configs/helpers-from-custom-dirs/stacks/stack.yml
@@ -1,0 +1,2 @@
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+regions: eu-north-1

--- a/integration-tests/stacks/configs/helpers-from-custom-dirs/takomo.yml
+++ b/integration-tests/stacks/configs/helpers-from-custom-dirs/takomo.yml
@@ -1,0 +1,1 @@
+helpersDir: custom-helpers

--- a/integration-tests/stacks/configs/helpers-from-custom-dirs/templates/stack.yml
+++ b/integration-tests/stacks/configs/helpers-from-custom-dirs/templates/stack.yml
@@ -1,0 +1,4 @@
+Description: {{ code }} {{ other }}
+Resources:
+  LG:
+    Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/test/helpers-from-custom-dirs.test.ts
+++ b/integration-tests/stacks/test/helpers-from-custom-dirs.test.ts
@@ -1,0 +1,31 @@
+import {
+  executeDeployStacksCommand,
+  withSingleAccountReservation,
+} from "@takomo/test-integration"
+
+const stackName = "stack",
+  stackPath = "/stack.yml/eu-north-1",
+  projectDir = "configs/helpers-from-custom-dirs"
+
+describe("Helpers from custom dirs", () => {
+  test(
+    "Deploy",
+    withSingleAccountReservation(async ({ accountId, credentials }) =>
+      executeDeployStacksCommand({ projectDir })
+        .expectCommandToSucceed()
+        .expectStackCreateSuccess({
+          stackName,
+          stackPath,
+        })
+        .expectDeployedCfStack({
+          credentials,
+          stackName,
+          accountId,
+          roleName: "OrganizationAccountAccessRole",
+          region: "eu-north-1",
+          expectedDescription: "CODE OTHER",
+        })
+        .assert(),
+    ),
+  )
+})

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -133,12 +133,14 @@ export const parseProjectConfigFile = async (
     ...overrideFeatures,
   }
   const varFiles = parseStringArray(parsedFile.varFiles)
+  const helpersDir = parseStringArray(parsedFile.helpersDir)
 
   return {
     regions,
     requiredVersion,
     resolvers,
     helpers,
+    helpersDir,
     features,
     varFiles,
     organization: parsedFile.organization,
@@ -192,6 +194,7 @@ export const takomoProjectConfigFileSchema = Joi.object({
   regions: Joi.array().items(Joi.string()).unique(),
   resolvers: Joi.array().items(Joi.string(), externalResolver),
   helpers: Joi.array().items(Joi.string(), externalHandlebarsHelper),
+  helpersDir: [Joi.string(), Joi.array().items(Joi.string())],
   varFiles,
   features,
 })
@@ -205,6 +208,7 @@ export const loadProjectConfig = async (
       regions: DEFAULT_REGIONS.slice(),
       resolvers: [],
       helpers: [],
+      helpersDir: [],
       varFiles: [],
       features: { ...defaultFeatures(), ...overrideFeatures },
     }

--- a/packages/config-repository-fs/src/stacks/config-repository.ts
+++ b/packages/config-repository-fs/src/stacks/config-repository.ts
@@ -9,6 +9,8 @@ import { ROOT_STACK_GROUP_PATH, SchemaRegistry } from "@takomo/stacks-model"
 import { ResolverRegistry } from "@takomo/stacks-resolvers"
 import {
   createTemplateEngine,
+  dirExists,
+  expandFilePath,
   FilePath,
   readFileContents,
   renderTemplate,
@@ -79,8 +81,17 @@ export const createFileSystemStacksConfigRepository = async ({
     templateEngine.registerHelper(helperWithName.name, helperWithName.fn)
   })
 
+  const defaultHelpersDirExists = await dirExists(helpersDir)
+  const additionalHelpersDirs = ctx.projectConfig.helpersDir.map((d) =>
+    expandFilePath(ctx.projectDir, d),
+  )
+
+  const helpersDirs = defaultHelpersDirExists
+    ? [helpersDir, ...additionalHelpersDirs]
+    : additionalHelpersDirs
+
   await Promise.all([
-    loadTemplateHelpers(helpersDir, logger, templateEngine),
+    loadTemplateHelpers(helpersDirs, logger, templateEngine),
     loadTemplatePartials(partialsDir, logger, templateEngine),
   ])
 

--- a/packages/config-repository-fs/src/template-engine.ts
+++ b/packages/config-repository-fs/src/template-engine.ts
@@ -9,12 +9,14 @@ import {
 import readdirp from "readdirp"
 
 export const loadTemplateHelpers = async (
-  helpersDir: FilePath,
+  helpersDirs: ReadonlyArray<FilePath>,
   logger: TkmLogger,
   te: TemplateEngine,
-) => {
-  if (await dirExists(helpersDir)) {
-    logger.debug(`Found helpers dir: ${helpersDir}`)
+): Promise<void> => {
+  for (const helpersDir of helpersDirs) {
+    if (!(await dirExists(helpersDir))) {
+      throw new TakomoError(`Helpers dir ${helpersDir} does not exists`)
+    }
 
     const helperFiles = await readdirp.promise(helpersDir, {
       alwaysStat: true,
@@ -38,8 +40,6 @@ export const loadTemplateHelpers = async (
       logger.debug(`Register helper: ${helper.name}`)
       te.registerHelper(helper.name, helper.fn)
     }
-  } else {
-    logger.debug("Helpers dir not found")
   }
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -77,6 +77,7 @@ export interface InternalTakomoProjectConfig extends TakomoProjectConfig {
   readonly helpers: ReadonlyArray<ExternalHandlebarsHelperConfig>
   readonly features: Features
   readonly varFiles: ReadonlyArray<FilePath>
+  readonly helpersDir: ReadonlyArray<FilePath>
 }
 
 /**


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/cli, @takomo/config-repository-fs, @takomo/core

ISSUES CLOSED: #276