### PR TITLE
fix(stacks): fix bug when undeploying a stack with obsolete dependents.

### DIFF
--- a/integration-tests/stacks/configs/undeploy-with-obsolete-dependent/stacks/config.yml
+++ b/integration-tests/stacks/configs/undeploy-with-obsolete-dependent/stacks/config.yml
@@ -1,0 +1,2 @@
+regions: eu-north-1
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole

--- a/integration-tests/stacks/configs/undeploy-with-obsolete-dependent/stacks/primary.yml
+++ b/integration-tests/stacks/configs/undeploy-with-obsolete-dependent/stacks/primary.yml
@@ -1,0 +1,5 @@
+template:
+  inline: |
+    Resources:
+      LG:
+        Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/configs/undeploy-with-obsolete-dependent/stacks/secondary.yml
+++ b/integration-tests/stacks/configs/undeploy-with-obsolete-dependent/stacks/secondary.yml
@@ -1,0 +1,7 @@
+obsolete: true
+depends: primary.yml
+template:
+  inline: |
+    Resources:
+      LG:
+        Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks/test/undeploy-with-obsolete-dependent.test.ts
+++ b/integration-tests/stacks/test/undeploy-with-obsolete-dependent.test.ts
@@ -1,0 +1,28 @@
+import {
+  executeDeployStacksCommand,
+  executeUndeployStacksCommand,
+} from "@takomo/test-integration"
+
+const projectDir = "configs/undeploy-with-obsolete-dependent"
+
+const primaryStack = {
+  stackName: "primary",
+  stackPath: "/primary.yml/eu-north-1",
+}
+
+describe("undeploying stacks with obsolete dependent stacks", () => {
+  test("deploy all", () =>
+    executeDeployStacksCommand({
+      projectDir,
+      commandPath: "/primary.yml/eu-north-1",
+    })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess(primaryStack)
+      .assert())
+
+  test("undeploy doesn't touch the obsolete stack", () =>
+    executeUndeployStacksCommand({ projectDir })
+      .expectCommandToSucceed()
+      .expectStackDeleteSuccess(primaryStack)
+      .assert())
+})

--- a/packages/cli-io/src/stacks/undeploy-stacks-io.ts
+++ b/packages/cli-io/src/stacks/undeploy-stacks-io.ts
@@ -57,13 +57,15 @@ const getConfirmUndeployText = (prune: boolean): ReadonlyArray<string> =>
   prune
     ? [
         "A stacks prune plan has been created and is shown below.",
-        "Stacks marked as obsolete will be undeployed in the order they are listed, and in parallel when possible.",
+        "Stacks marked as obsolete will be undeployed in the order they",
+        "are listed, and in parallel when possible.",
         "",
         "Following stacks will be undeployed:",
       ]
     : [
         "A stacks undeployment plan has been created and is shown below.",
-        "Stacks will be undeployed in the order they are listed, and in parallel when possible.",
+        "Stacks will be undeployed in the order they are listed, and in",
+        "parallel when possible.",
         "",
         "Following stacks will be undeployed:",
       ]
@@ -90,7 +92,7 @@ export const createUndeployStacksIO = (
 
     const stackPathColumnLength = Math.max(27, maxStackPathLength)
 
-    for (const { stack, currentStack, type } of operations) {
+    for (const { stack, currentStack, type, dependents } of operations) {
       const stackIdentity = await stack.credentialManager.getCallerIdentity()
 
       io.longMessage(
@@ -112,9 +114,9 @@ export const createUndeployStacksIO = (
         0,
       )
 
-      if (stack.dependents.length > 0) {
+      if (dependents.length > 0) {
         io.message({ text: "dependents:", indent: 6 })
-        stack.dependents.forEach((d) => {
+        dependents.forEach((d) => {
           io.message({ text: `- ${d}`, indent: 8 })
         })
       } else {

--- a/packages/cli-io/test/stacks/undeploy-stacks/confirm-undeploy.test.ts
+++ b/packages/cli-io/test/stacks/undeploy-stacks/confirm-undeploy.test.ts
@@ -48,6 +48,7 @@ const mockOperation = (
   return {
     type,
     currentStack,
+    dependents: stackProps.dependents ?? [],
     stack: mockInternalStack(stackProps),
   }
 }
@@ -57,7 +58,7 @@ const confirmUndeploy = (
 ): Promise<string> => {
   const output = { value: "" }
   return createIO(createCapturingLogWriter(output))
-    .confirmUndeploy({ operations })
+    .confirmUndeploy({ operations, prune: false })
     .then(() => output.value)
 }
 
@@ -75,7 +76,8 @@ describe("UndeployStacksIO#confirmUndeploy", () => {
       ${bold("Review stacks undeployment plan:")}
       ${bold("--------------------------------")}
       A stacks undeployment plan has been created and is shown below.
-      Stacks will be undeployed in the order they are listed, and in parallel when possible.
+      Stacks will be undeployed in the order they are listed, and in
+      parallel when possible.
       
       Following stacks will be undeployed:
       
@@ -110,7 +112,8 @@ describe("UndeployStacksIO#confirmUndeploy", () => {
       ${bold("Review stacks undeployment plan:")}
       ${bold("--------------------------------")}
       A stacks undeployment plan has been created and is shown below.
-      Stacks will be undeployed in the order they are listed, and in parallel when possible.
+      Stacks will be undeployed in the order they are listed, and in
+      parallel when possible.
       
       Following stacks will be undeployed:
       
@@ -156,7 +159,8 @@ describe("UndeployStacksIO#confirmUndeploy", () => {
       ${bold("Review stacks undeployment plan:")}
       ${bold("--------------------------------")}
       A stacks undeployment plan has been created and is shown below.
-      Stacks will be undeployed in the order they are listed, and in parallel when possible.
+      Stacks will be undeployed in the order they are listed, and in
+      parallel when possible.
       
       Following stacks will be undeployed:
       
@@ -228,7 +232,8 @@ describe("UndeployStacksIO#confirmUndeploy", () => {
       ${bold("Review stacks undeployment plan:")}
       ${bold("--------------------------------")}
       A stacks undeployment plan has been created and is shown below.
-      Stacks will be undeployed in the order they are listed, and in parallel when possible.
+      Stacks will be undeployed in the order they are listed, and in
+      parallel when possible.
       
       Following stacks will be undeployed:
 

--- a/packages/stacks-commands/src/stacks/undeploy/execute-undeploy-context.ts
+++ b/packages/stacks-commands/src/stacks/undeploy/execute-undeploy-context.ts
@@ -55,7 +55,7 @@ export const executeUndeployContext = async (
   const executions = operations.reduce((executions, operation) => {
     const dependents = ignoreDependencies
       ? []
-      : operation.stack.dependents.map((d) => executions.get(d)!)
+      : operation.dependents.map((d) => executions.get(d)!)
 
     const execution = bulkhead.execute(() =>
       deleteStack(


### PR DESCRIPTION
affects: integration-test-stacks, @takomo/cli-io, @takomo/stacks-commands

When a stack was undeployed, also its obsolete dependents were chosen to be undeployed.