### PR TITLE
fix: fix diffing of stack policies

### DIFF
--- a/packages/cli-io/src/stacks/deploy-stacks/stack-policy.ts
+++ b/packages/cli-io/src/stacks/deploy-stacks/stack-policy.ts
@@ -11,7 +11,8 @@ const ensureContentsEndsWithLineFeed = (content: string): string =>
   content.endsWith("\n") ? content : content + "\n"
 
 type PolicyOperationType = "create" | "delete" | "update" | "retain"
-const resolvePolicyOperation = (
+
+export const resolvePolicyOperation = (
   current: StackPolicyBody | undefined,
   updated: StackPolicyBody | undefined,
 ): PolicyOperationType => {
@@ -34,7 +35,10 @@ const resolvePolicyOperation = (
     return "delete"
   }
 
-  if (current === updated) {
+  const currentFormatted = current ? prettyPrintJson(current) : ""
+  const updatedFormatted = updated ? prettyPrintJson(updated) : ""
+
+  if (currentFormatted === updatedFormatted) {
     return "retain"
   }
 
@@ -69,7 +73,7 @@ export const printStackPolicy = (
         marginBottom: true,
       })
       io.message({
-        text: stack.stackPolicy!,
+        text: prettyPrintJson(stack.stackPolicy!),
         transform: (str) =>
           green(
             str
@@ -96,8 +100,12 @@ export const printStackPolicy = (
 
       io.message({
         text: diffStrings(
-          ensureContentsEndsWithLineFeed(existingStack!.stackPolicyBody!),
-          ensureContentsEndsWithLineFeed(ALLOW_ALL_STACK_POLICY),
+          ensureContentsEndsWithLineFeed(
+            prettyPrintJson(existingStack!.stackPolicyBody!),
+          ),
+          ensureContentsEndsWithLineFeed(
+            prettyPrintJson(ALLOW_ALL_STACK_POLICY),
+          ),
         ),
         indent: 2,
       })
@@ -109,9 +117,11 @@ export const printStackPolicy = (
         marginBottom: true,
       })
       const current = ensureContentsEndsWithLineFeed(
-        existingStack?.stackPolicyBody ?? "",
+        prettyPrintJson(existingStack!.stackPolicyBody!),
       )
-      const updated = ensureContentsEndsWithLineFeed(stack.stackPolicy ?? "")
+      const updated = ensureContentsEndsWithLineFeed(
+        prettyPrintJson(stack.stackPolicy!),
+      )
       const diffOutput = diffStrings(current, updated)
       io.message({ text: diffOutput, indent: 2 })
       break

--- a/packages/cli-io/test/stacks/deploy-stacks/print-stack-policy.test.ts
+++ b/packages/cli-io/test/stacks/deploy-stacks/print-stack-policy.test.ts
@@ -1,0 +1,100 @@
+import { DetailedCloudFormationStack } from "@takomo/aws-model"
+import { InternalStack } from "@takomo/stacks-model"
+import { createCapturingLogWriter } from "@takomo/test-unit"
+import { bold, green } from "@takomo/util"
+import { mock } from "jest-mock-extended"
+import { createBaseIO } from "../../../src/cli-io"
+import { printStackPolicy } from "../../../src/stacks/deploy-stacks/stack-policy"
+
+const doPrintStackPolicy = (
+  updatedStack: InternalStack,
+  currentStack?: DetailedCloudFormationStack,
+): string => {
+  const output = { value: "" }
+
+  printStackPolicy(
+    createBaseIO({ writer: createCapturingLogWriter(output) }),
+    updatedStack,
+    currentStack,
+  )
+
+  return output.value
+}
+
+const policy1 = `
+ {
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "Update:*",
+        "Principal": "*",
+        "Resource": "*"
+      }
+    ]
+  }
+`
+
+const policy2 = `
+ {
+    "Statement": [
+      {
+        "Action": "Update:*",
+        "Principal": "*",
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }
+`
+
+const updatedStack = (stackPolicy?: string): InternalStack =>
+  mock<InternalStack>({ stackPolicy })
+
+const currentStack = (stackPolicyBody?: string): DetailedCloudFormationStack =>
+  mock<DetailedCloudFormationStack>({ stackPolicyBody })
+
+describe("#printStackPolicy", () => {
+  test("current stack exists but it doesn't have stack policy and neither does updated stack", () => {
+    const output = doPrintStackPolicy(updatedStack(), currentStack())
+    expect(output).toStrictEqual("")
+  })
+
+  test("current stack and updated stacks have same policy", () => {
+    const output = doPrintStackPolicy(
+      updatedStack(policy1),
+      currentStack(policy1),
+    )
+    expect(output).toStrictEqual("")
+  })
+
+  test("current stack and updated stacks have same policy but properties are in different order", () => {
+    const output = doPrintStackPolicy(
+      updatedStack(policy1),
+      currentStack(policy2),
+    )
+    expect(output).toStrictEqual("")
+  })
+
+  test("current stack exists but it doesn't have stack policy and updated stack has policy", () => {
+    const output = doPrintStackPolicy(updatedStack(policy1), currentStack())
+
+    const expected =
+      `\n${bold("Stack policy:")}\n\n` +
+      `  Stack policy will be created\n\n` +
+      green(
+        `  + {\n` +
+          `  +   "Statement": [\n` +
+          `  +     {\n` +
+          `  +       "Action": "Update:*",\n` +
+          `  +       "Effect": "Allow",\n` +
+          `  +       "Principal": "*",\n` +
+          `  +       "Resource": "*"\n` +
+          `  +     }\n` +
+          `  +   ]\n` +
+          `  + }`,
+      ) +
+      "\n"
+
+    expect(output).toStrictEqual(expected)
+  })
+})

--- a/packages/cli-io/test/stacks/deploy-stacks/resolve-policy-operation.test.ts
+++ b/packages/cli-io/test/stacks/deploy-stacks/resolve-policy-operation.test.ts
@@ -1,0 +1,76 @@
+import { resolvePolicyOperation } from "../../../src/stacks/deploy-stacks/stack-policy"
+
+const policy1 = `
+ {
+    "Statement": [
+      {
+        "Effect": "Deny",
+        "Action": ["Update:Replace", "Update:Delete"],
+        "Principal": "*",
+        "Resource": "*",
+        "Condition": {
+          "StringEquals": {
+            "ResourceType": [
+              "AWS::Cognito::UserPool",
+              "AWS::Cognito::UserPoolClient"
+            ]
+          }
+        }
+      },
+      {
+        "Effect": "Allow",
+        "Action": "Update:*",
+        "Principal": "*",
+        "Resource": "*"
+      }
+    ]
+  }
+`
+
+const policy2 = `
+ {
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "Update:*",
+        "Principal": "*",
+        "Resource": "*"
+      }
+    ]
+  }
+`
+
+const policy3 = `
+ {
+    "Statement": [
+      {
+        "Action": "Update:*",
+        "Effect": "Allow",
+        "Resource": "*",
+        "Principal": "*"
+      }
+    ]
+  }
+`
+
+describe("#resolvePolicyOperation", () => {
+  test("current and updated are undefined", () => {
+    expect(resolvePolicyOperation(undefined, undefined)).toBe("retain")
+  })
+
+  test("current and updated are different", () => {
+    expect(resolvePolicyOperation(policy1, policy2)).toBe("update")
+  })
+
+  test("current is defined and updated is undefined", () => {
+    expect(resolvePolicyOperation(policy1, undefined)).toBe("delete")
+  })
+
+  test("current is undefined and updated is defined", () => {
+    expect(resolvePolicyOperation(undefined, policy2)).toBe("create")
+  })
+
+  test("current and updated are same but have different order of properties", () => {
+    expect(resolvePolicyOperation(policy2, policy3)).toBe("retain")
+  })
+})


### PR DESCRIPTION
affects: @takomo/cli-io

Stack policies were incorrectly compared as text when the
right way would have been comparing them as objects. Due
to this, two policies with identical properties but in a different
order were deemed different.