### PR TITLE
fix: retain original tag value type when constructing stack tags from…

### DIFF
--- a/integration-tests/stacks2/configs/tags/schemas/tag-schema.js
+++ b/integration-tests/stacks2/configs/tags/schemas/tag-schema.js
@@ -1,0 +1,16 @@
+const init = ({ joi }) => {
+  return joi.object({
+    first: joi.string(),
+    second: joi.number(),
+    third: joi.boolean(),
+    fourth: joi.boolean(),
+    fifth: joi.number(),
+    sixth: joi.string(),
+    seventh: joi.string(),
+  })
+}
+
+module.exports = {
+  name: "common-tags",
+  init,
+}

--- a/integration-tests/stacks2/configs/tags/stacks/tags.yml
+++ b/integration-tests/stacks2/configs/tags/stacks/tags.yml
@@ -1,0 +1,17 @@
+regions: eu-north-1
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+tags:
+  first: this is string value
+  second: 999
+  third: true
+  fourth: false
+  fifth: 0
+  sixth: "000001"
+  seventh: "9"
+schemas:
+  tags: common-tags
+template:
+  inline: |
+    Resources:
+      LG:
+        Type: AWS::Logs::LogGroup

--- a/integration-tests/stacks2/test/tag-inheritance.test.ts
+++ b/integration-tests/stacks2/test/tag-inheritance.test.ts
@@ -1,67 +1,45 @@
-import {
-  executeDeployStacksCommand,
-  withSingleAccountReservation,
-} from "@takomo/test-integration"
+import { executeDeployStacksCommand } from "@takomo/test-integration"
 
 describe("Tag inheritance", () => {
-  test(
-    "Deploy",
-    withSingleAccountReservation(({ credentials, accountId }) =>
-      executeDeployStacksCommand({
-        projectDir: "configs/tag-inheritance",
-      })
-        .expectCommandToSucceed()
-        .expectStackCreateSuccess(
-          {
-            stackName: "three",
-            stackPath: "/three.yml/eu-north-1",
-          },
-          {
-            stackName: "aaa-two",
-            stackPath: "/aaa/two.yml/eu-north-1",
-          },
-          {
-            stackName: "aaa-bbb-one",
-            stackPath: "/aaa/bbb/one.yml/eu-north-1",
-          },
-        )
-        .expectDeployedCfStack({
-          credentials,
-          accountId,
+  test("Deploy", () =>
+    executeDeployStacksCommand({
+      projectDir: "configs/tag-inheritance",
+    })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess(
+        {
           stackName: "three",
-          region: "eu-north-1",
-          roleName: "OrganizationAccountAccessRole",
-          expectedTags: {
-            foo: "bar",
-            fux: "baz",
-            hello: "world",
+          stackPath: "/three.yml/eu-north-1",
+          expectDeployedStack: {
+            tags: {
+              foo: "bar",
+              fux: "baz",
+              hello: "world",
+            },
           },
-        })
-        .expectDeployedCfStack({
-          credentials,
-          accountId,
+        },
+        {
           stackName: "aaa-two",
-          region: "eu-north-1",
-          roleName: "OrganizationAccountAccessRole",
-          expectedTags: {
-            foo: "bar1",
-            fux: "baz",
-            hello: "world",
+          stackPath: "/aaa/two.yml/eu-north-1",
+          expectDeployedStack: {
+            tags: {
+              foo: "bar1",
+              fux: "baz",
+              hello: "world",
+            },
           },
-        })
-        .expectDeployedCfStack({
-          credentials,
-          accountId,
+        },
+        {
           stackName: "aaa-bbb-one",
-          region: "eu-north-1",
-          roleName: "OrganizationAccountAccessRole",
-          expectedTags: {
-            foo: "bar1",
-            fux: "new-value",
-            hello: "world",
+          stackPath: "/aaa/bbb/one.yml/eu-north-1",
+          expectDeployedStack: {
+            tags: {
+              foo: "bar1",
+              fux: "new-value",
+              hello: "world",
+            },
           },
-        })
-        .assert(),
-    ),
-  )
+        },
+      )
+      .assert())
 })

--- a/integration-tests/stacks2/test/tags.test.ts
+++ b/integration-tests/stacks2/test/tags.test.ts
@@ -1,0 +1,27 @@
+import { executeDeployStacksCommand } from "@takomo/test-integration/src"
+
+const stackPath = "/tags.yml/eu-north-1",
+  stackName = "tags",
+  projectDir = "configs/tags"
+
+describe("Stack tags", () => {
+  test("Deploy", () =>
+    executeDeployStacksCommand({ projectDir })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess({
+        stackPath,
+        stackName,
+        expectDeployedStack: {
+          tags: {
+            first: "this is string value",
+            second: "999",
+            third: "true",
+            fourth: "false",
+            fifth: "0",
+            sixth: "000001",
+            seventh: "9",
+          },
+        },
+      })
+      .assert())
+})

--- a/packages/stacks-config/src/model.ts
+++ b/packages/stacks-config/src/model.ts
@@ -6,11 +6,11 @@ import {
   StackParameterKey,
   StackPolicyBody,
   TagKey,
-  TagValue,
 } from "@takomo/aws-model"
 import { CommandRole, Project, Vars } from "@takomo/core"
 import {
   HookConfig,
+  RawTagValue,
   ResolverName,
   StackPath,
   TemplateBucketConfig,
@@ -91,7 +91,7 @@ export interface StackConfig {
   readonly commandRole?: CommandRole
   readonly timeout?: TimeoutConfig
   readonly depends: ReadonlyArray<StackPath>
-  readonly tags: Map<TagKey, TagValue>
+  readonly tags: Map<TagKey, RawTagValue>
   readonly inheritTags: boolean
   readonly parameters: Map<StackParameterKey, ParameterConfigs>
   readonly data: Vars
@@ -111,7 +111,7 @@ export interface StackGroupConfig {
   readonly accountIds?: ReadonlyArray<AccountId>
   readonly commandRole?: CommandRole
   readonly templateBucket?: TemplateBucketConfig
-  readonly tags: Map<TagKey, TagValue>
+  readonly tags: Map<TagKey, RawTagValue>
   readonly inheritTags: boolean
   readonly timeout?: TimeoutConfig
   readonly hooks: ReadonlyArray<HookConfig>

--- a/packages/stacks-config/src/parse-tags.ts
+++ b/packages/stacks-config/src/parse-tags.ts
@@ -1,14 +1,10 @@
-import { TagKey, TagValue } from "@takomo/aws-model"
+import { TagKey } from "@takomo/aws-model"
+import { RawTagValue } from "@takomo/stacks-model"
 
-export const parseTags = (value: any): Map<TagKey, TagValue> => {
+export const parseTags = (value: any): Map<TagKey, RawTagValue> => {
   if (value === null || value === undefined) {
     return new Map()
   }
 
-  return new Map(
-    Object.entries(value).map((e) => {
-      const [k, v] = e
-      return [k, `${v}`]
-    }),
-  )
+  return new Map(Object.entries(value).map(([k, v]) => [k, v as RawTagValue]))
 }

--- a/packages/stacks-config/test/build-stack-group-config.test.ts
+++ b/packages/stacks-config/test/build-stack-group-config.test.ts
@@ -1,5 +1,7 @@
 import { AwsClientProvider } from "@takomo/aws-clients/src"
+import { TagKey } from "@takomo/aws-model"
 import { CommandContext, TakomoProjectConfig } from "@takomo/core"
+import { RawTagValue } from "@takomo/stacks-model"
 import { mock } from "jest-mock-extended"
 import { buildStackGroupConfig } from "../src"
 
@@ -73,8 +75,8 @@ describe("#buildStackGroupConfig", () => {
       project: "example-project",
       regions: ["eu-west-1"],
       accountIds: undefined,
-      tags: new Map([
-        ["first", "1"],
+      tags: new Map<TagKey, RawTagValue>([
+        ["first", 1],
         ["second", "b"],
       ]),
       inheritTags: true,

--- a/packages/stacks-config/test/parse-tags.test.ts
+++ b/packages/stacks-config/test/parse-tags.test.ts
@@ -1,0 +1,36 @@
+import { parseTags } from "../src/parse-tags"
+
+describe("#parseTags", () => {
+  test("when undefined is given", () => {
+    expect(parseTags(undefined)).toStrictEqual(new Map())
+  })
+  test("when null is given", () => {
+    expect(parseTags(null)).toStrictEqual(new Map())
+  })
+  test("when empty object is given", () => {
+    expect(parseTags({})).toStrictEqual(new Map())
+  })
+  test("when object with single string tag value is given", () => {
+    const value = { one: "two" }
+    const expected = new Map([["one", "two"]])
+    expect(parseTags(value)).toStrictEqual(expected)
+  })
+  test("when object with multiple string tag values is given", () => {
+    const value = { one: "two", cool: "yes-sir" }
+    const expected = new Map([
+      ["one", "two"],
+      ["cool", "yes-sir"],
+    ])
+    expect(parseTags(value)).toStrictEqual(expected)
+  })
+  test("when object with single number tag value is given", () => {
+    const value = { num: 1023 }
+    const expected = new Map([["num", 1023]])
+    expect(parseTags(value)).toStrictEqual(expected)
+  })
+  test("when object with single boolean tag value is given", () => {
+    const value = { x: false }
+    const expected = new Map([["x", false]])
+    expect(parseTags(value)).toStrictEqual(expected)
+  })
+})

--- a/packages/stacks-context/src/config/build-stack.ts
+++ b/packages/stacks-context/src/config/build-stack.ts
@@ -10,6 +10,7 @@ import {
   InternalStack,
   isWithinCommandPath,
   normalizeStackPath,
+  RawTagValue,
   SchemaRegistry,
   StackGroup,
   StackPath,
@@ -74,7 +75,7 @@ const validateData = (
 const validateTags = (
   stackPath: StackPath,
   schemas: ReadonlyArray<AnySchema>,
-  tags: Map<string, string>,
+  tags: Map<string, RawTagValue>,
 ): void => {
   schemas.forEach((schema) => {
     const tagsObject = mapToObject(tags)

--- a/packages/stacks-model/src/index.ts
+++ b/packages/stacks-model/src/index.ts
@@ -18,6 +18,7 @@ export {
   createStack,
   InternalStack,
   normalizeStackPath,
+  RawTagValue,
   Stack,
   StackPath,
   StackProps,

--- a/packages/stacks-model/src/stack-group.ts
+++ b/packages/stacks-model/src/stack-group.ts
@@ -4,13 +4,12 @@ import {
   StackCapability,
   StackPolicyBody,
   TagKey,
-  TagValue,
 } from "@takomo/aws-model"
 import { CommandRole, Project, Vars } from "@takomo/core"
 import { TemplateBucketConfig, TimeoutConfig } from "./common"
 import { HookConfig } from "./hook"
 import { Schemas } from "./schemas"
-import { InternalStack } from "./stack"
+import { InternalStack, RawTagValue } from "./stack"
 
 export type StackGroupPath = string
 export type StackGroupName = string
@@ -30,7 +29,7 @@ export interface StackGroupProps {
   children: ReadonlyArray<StackGroup>
   stacks: ReadonlyArray<InternalStack>
   timeout?: TimeoutConfig
-  tags: Map<TagKey, TagValue>
+  tags: Map<TagKey, RawTagValue>
   hooks: ReadonlyArray<HookConfig>
   data: Vars
   capabilities?: ReadonlyArray<StackCapability>
@@ -58,7 +57,7 @@ export interface StackGroup {
   readonly children: ReadonlyArray<StackGroup>
   readonly stacks: ReadonlyArray<InternalStack>
   readonly timeout?: TimeoutConfig
-  readonly tags: Map<TagKey, TagValue>
+  readonly tags: Map<TagKey, RawTagValue>
   readonly hooks: ReadonlyArray<HookConfig>
   readonly data: Record<string, unknown>
   readonly capabilities?: ReadonlyArray<StackCapability>

--- a/packages/stacks-model/src/stack.ts
+++ b/packages/stacks-model/src/stack.ts
@@ -9,7 +9,6 @@ import {
   StackParameterKey,
   StackPolicyBody,
   TagKey,
-  TagValue,
 } from "@takomo/aws-model"
 import { CommandRole, Project, Vars } from "@takomo/core"
 import { FilePath, TkmLogger } from "@takomo/util"
@@ -19,6 +18,8 @@ import { HookExecutor } from "./hook"
 import { ResolverExecutor } from "./resolver"
 import { Schemas } from "./schemas"
 import { StackGroupName, StackGroupPath } from "./stack-group"
+
+export type RawTagValue = string | number | boolean
 
 /**
  * Stack path.
@@ -47,7 +48,7 @@ export interface StackProps {
   region: Region
   accountIds: ReadonlyArray<AccountId>
   commandRole?: CommandRole
-  tags: Map<TagKey, TagValue>
+  tags: Map<TagKey, RawTagValue>
   timeout: TimeoutConfig
   parameters: Map<StackParameterKey, ResolverExecutor>
   dependencies: ReadonlyArray<StackPath>
@@ -148,7 +149,7 @@ export interface InternalStack extends Stack {
   readonly templateBucket?: TemplateBucketConfig
   readonly accountIds: ReadonlyArray<AccountId>
   readonly commandRole?: CommandRole
-  readonly tags: Map<TagKey, TagValue>
+  readonly tags: Map<TagKey, RawTagValue>
   readonly timeout: TimeoutConfig
   readonly parameters: Map<StackParameterKey, ResolverExecutor>
   readonly hooks: ReadonlyArray<HookExecutor>


### PR DESCRIPTION
… configuration files.

affects: integration-test-stacks2, @takomo/stacks-config, @takomo/stacks-context,
@takomo/stacks-model

ISSUES CLOSED: #360