### PR TITLE
feat: show target name in deployment targets stack operation summary

### DIFF
--- a/integration-test/src/commands/targets/common.ts
+++ b/integration-test/src/commands/targets/common.ts
@@ -1,6 +1,6 @@
 import {
-  InternalCredentialManager,
   initDefaultCredentialManager,
+  InternalCredentialManager,
 } from "../../../../src/takomo-aws-clients"
 import {
   createFileSystemDeploymentTargetsConfigRepository,

--- a/src/takomo-cli-io/deployment-targets/deployment-operation-io.ts
+++ b/src/takomo-cli-io/deployment-targets/deployment-operation-io.ts
@@ -5,6 +5,7 @@ import {
   ConfirmOperationAnswer,
   DeploymentTargetsOperationIO,
   DeploymentTargetsOperationOutput,
+  PlannedDeploymentTarget,
   TargetsExecutionPlan,
 } from "../../takomo-deployment-targets-commands"
 import { DeployStacksIO, UndeployStacksIO } from "../../takomo-stacks-commands"
@@ -72,11 +73,15 @@ export const createDeploymentTargetsOperationIO = (
   const { logger, messages } = props
   const io = createBaseIO(props)
 
-  const createStackDeployIO = (logger: TkmLogger): DeployStacksIO =>
-    createDeployStacksIO({ logger })
+  const createStackDeployIO = (
+    logger: TkmLogger,
+    target: PlannedDeploymentTarget,
+  ): DeployStacksIO => createDeployStacksIO({ logger, target: target.name })
 
-  const createStackUndeployIO = (logger: TkmLogger): UndeployStacksIO =>
-    createUndeployStacksIO({ logger })
+  const createStackUndeployIO = (
+    logger: TkmLogger,
+    target: PlannedDeploymentTarget,
+  ): UndeployStacksIO => createUndeployStacksIO({ logger, target: target.name })
 
   const printOutput = (
     output: DeploymentTargetsOperationOutput,

--- a/src/takomo-cli-io/stacks/common.ts
+++ b/src/takomo-cli-io/stacks/common.ts
@@ -86,23 +86,36 @@ interface OutputStackResult {
   readonly status: CommandStatus
   readonly time: number
   readonly message: string
+  readonly target?: string
 }
 
-const toOutputStackResult = (result: StackResult): OutputStackResult => ({
+const toOutputStackResult = (
+  result: StackResult,
+  target?: string,
+): OutputStackResult => ({
   path: result.stack.path,
   name: result.stack.name,
   status: result.status,
   time: result.timer.getSecondsElapsed(),
   message: result.message,
+  target,
 })
 
-export const printStacksOperationOutput = (
-  io: BaseIO,
-  output: StacksOperationOutput,
-  logLevel: LogLevel,
-): StacksOperationOutput => {
+interface PrintStacksOperationOutputProps {
+  readonly io: BaseIO
+  readonly output: StacksOperationOutput
+  readonly logLevel: LogLevel
+  readonly target?: string
+}
+
+export const printStacksOperationOutput = ({
+  io,
+  output,
+  logLevel,
+  target,
+}: PrintStacksOperationOutputProps): StacksOperationOutput => {
   const { outputFormat, results } = output
-  const stacks = results.map(toOutputStackResult)
+  const stacks = results.map((r) => toOutputStackResult(r, target))
 
   if (outputFormat === "json") {
     io.message({
@@ -142,6 +155,10 @@ export const printStacksOperationOutput = (
 
   const table = new Table()
   output.results.forEach((result) => {
+    if (target) {
+      table.cell("Target", target)
+    }
+
     table
       .cell("Path", result.stack.path)
       .cell("Name", result.stack.name)

--- a/src/takomo-cli-io/stacks/deploy-stacks/deploy-stacks-io.ts
+++ b/src/takomo-cli-io/stacks/deploy-stacks/deploy-stacks-io.ts
@@ -122,12 +122,14 @@ const formatStackOperationType = (type: StackOperationType): string => {
 const ensureContentsEndsWithLineFeed = (content: string): string =>
   content.endsWith("\n") ? content : content + "\n"
 
-export type DeployStacksIOProps = IOProps
+export interface DeployStacksIOProps extends IOProps {
+  readonly target?: string
+}
 
 export const createDeployStacksIO = (
   props: DeployStacksIOProps,
 ): DeployStacksIO => {
-  const { logger } = props
+  const { logger, target } = props
   const io = createBaseIO(props)
 
   // TODO: Come up some other solution
@@ -234,7 +236,12 @@ export const createDeployStacksIO = (
   }
 
   const printOutput = (output: StacksOperationOutput): StacksOperationOutput =>
-    printStacksOperationOutput(io, output, logger.logLevel)
+    printStacksOperationOutput({
+      io,
+      output,
+      logLevel: logger.logLevel,
+      target,
+    })
 
   const confirmStackDeploy = async (
     stack: InternalStack,

--- a/src/takomo-cli-io/stacks/undeploy-stacks-io.ts
+++ b/src/takomo-cli-io/stacks/undeploy-stacks-io.ts
@@ -70,12 +70,14 @@ const getConfirmUndeployText = (prune: boolean): ReadonlyArray<string> =>
         "Following stacks will be undeployed:",
       ]
 
-export type UndeployStacksIOProps = IOProps
+export interface UndeployStacksIOProps extends IOProps {
+  readonly target?: string
+}
 
 export const createUndeployStacksIO = (
   props: UndeployStacksIOProps,
 ): UndeployStacksIO => {
-  const { logger } = props
+  const { logger, target } = props
   const io = createBaseIO(props)
 
   const confirmUndeploy = async ({
@@ -159,7 +161,12 @@ export const createUndeployStacksIO = (
     logger.info(stackPath + " - " + formatStackEvent(e))
 
   const printOutput = (output: StacksOperationOutput): StacksOperationOutput =>
-    printStacksOperationOutput(io, output, logger.logLevel)
+    printStacksOperationOutput({
+      io,
+      output,
+      logLevel: logger.logLevel,
+      target,
+    })
 
   const chooseCommandPath = (rootStackGroup: StackGroup) =>
     chooseCommandPathInternal(io, rootStackGroup)

--- a/src/takomo-deployment-targets-commands/operation/execute.ts
+++ b/src/takomo-deployment-targets-commands/operation/execute.ts
@@ -38,7 +38,7 @@ interface CreateExecutorProps {
 const executeOperationInternal = async (
   operation: DeploymentOperation,
   input: StacksOperationInput,
-  account: PlannedDeploymentTarget,
+  target: PlannedDeploymentTarget,
   credentialManager: InternalCredentialManager,
   io: DeploymentTargetsOperationIO,
   ctx: InternalCommandContext,
@@ -57,7 +57,7 @@ const executeOperationInternal = async (
         ctx,
         credentialManager,
         configRepository,
-        io: io.createStackDeployIO(logger),
+        io: io.createStackDeployIO(logger, target),
       })
     case "undeploy":
       return undeployStacksCommand({
@@ -68,7 +68,7 @@ const executeOperationInternal = async (
         ctx,
         credentialManager,
         configRepository,
-        io: io.createStackUndeployIO(logger),
+        io: io.createStackUndeployIO(logger, target),
       })
     default:
       throw new Error(`Unsupported operation: ${operation}`)

--- a/src/takomo-deployment-targets-commands/operation/model.ts
+++ b/src/takomo-deployment-targets-commands/operation/model.ts
@@ -56,8 +56,14 @@ export interface DeploymentTargetsListener {
 
 export interface DeploymentTargetsOperationIO
   extends IO<DeploymentTargetsOperationOutput> {
-  readonly createStackDeployIO: (logger: TkmLogger) => DeployStacksIO
-  readonly createStackUndeployIO: (logger: TkmLogger) => UndeployStacksIO
+  readonly createStackDeployIO: (
+    logger: TkmLogger,
+    target: PlannedDeploymentTarget,
+  ) => DeployStacksIO
+  readonly createStackUndeployIO: (
+    logger: TkmLogger,
+    target: PlannedDeploymentTarget,
+  ) => UndeployStacksIO
   readonly confirmOperation: (
     plan: TargetsExecutionPlan,
   ) => Promise<ConfirmOperationAnswer>


### PR DESCRIPTION
Previously, when deployment targets were deployed or undeployed, the stack operation summary shown after each completed target, didn't include information about in which target the stacks belonged to. After this change, the target name is shown in stack operation summaries.