### PR TITLE
fix: fix validating of command roles

### DIFF
--- a/integration-test/configs/deploy/command-roles/blueprints/example.yml
+++ b/integration-test/configs/deploy/command-roles/blueprints/example.yml
@@ -1,0 +1,7 @@
+regions: eu-north-1
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/OrganizationAccountAccessRole
+template:
+  inline: |
+    Resources:
+      LogGroup:
+        Type: AWS::Logs::LogGroup

--- a/integration-test/configs/deploy/command-roles/stacks/aaa/one.yml
+++ b/integration-test/configs/deploy/command-roles/stacks/aaa/one.yml
@@ -1,0 +1,1 @@
+blueprint: example.yml

--- a/integration-test/configs/deploy/command-roles/stacks/bbb/two.yml
+++ b/integration-test/configs/deploy/command-roles/stacks/bbb/two.yml
@@ -1,0 +1,2 @@
+blueprint: example.yml
+commandRole: arn:aws:iam::{{ var.ACCOUNT_1_ID }}:role/NonExistingRole

--- a/integration-test/test/deploy/deploy-with-command-roles.test.ts
+++ b/integration-test/test/deploy/deploy-with-command-roles.test.ts
@@ -1,0 +1,36 @@
+import { executeDeployStacksCommand } from "../../src/commands/stacks"
+import { withSingleAccountReservation } from "../../src/reservations"
+import { pathToConfigs } from "../../src/util"
+
+const projectDir = pathToConfigs("deploy", "command-roles")
+
+describe("Deploy", () => {
+  test("In interactive mode, should not attempt to assume command roles of stacks that are not selected for deploy", () =>
+    executeDeployStacksCommand({
+      projectDir,
+      interactive: true,
+      answers: {
+        chooseCommandPath: "/aaa/one.yml",
+        confirmDeploy: "CONTINUE_NO_REVIEW",
+        confirmStackDeploy: "CONTINUE_AND_SKIP_REMAINING_REVIEWS",
+      },
+    })
+      .expectCommandToSucceed()
+      .expectStackCreateSuccess({
+        stackPath: "/aaa/one.yml/eu-north-1",
+        stackName: "aaa-one",
+      })
+      .assert())
+
+  test(
+    "Should fail if can't assume command roles",
+    withSingleAccountReservation(({ accountId }) =>
+      executeDeployStacksCommand({
+        projectDir,
+        commandPath: "/bbb/two.yml",
+      }).expectCommandToThrow(
+        `is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::${accountId}:role/NonExistingRole`,
+      ),
+    ),
+  )
+})

--- a/integration-test/test/undeploy/undeploy-with-command-roles.test.ts
+++ b/integration-test/test/undeploy/undeploy-with-command-roles.test.ts
@@ -1,14 +1,31 @@
 import { executeUndeployStacksCommand } from "../../src/commands/stacks"
-import { pathToConfigs } from "../../src/util"
 import { withSingleAccountReservation } from "../../src/reservations"
+import { pathToConfigs } from "../../src/util"
 
 const projectDir = pathToConfigs("undeploy", "command-roles")
 
 describe("Undeploy", () => {
   test("Should not attempt to assume command roles of stacks that are not selected for undeploy", () =>
     executeUndeployStacksCommand({
+      commandPath: "/aaa/one.yml/eu-north-1",
       projectDir,
-      commandPath: "/aaa/one.yml",
+    })
+      .expectCommandToSkip("Skipped")
+      .expectSkippedStackResult({
+        stackPath: "/aaa/one.yml/eu-north-1",
+        message: "Stack not found",
+        stackName: "aaa-one",
+      })
+      .assert())
+
+  test("In interactive mode, should not attempt to assume command roles of stacks that are not selected for undeploy", () =>
+    executeUndeployStacksCommand({
+      projectDir,
+      interactive: true,
+      answers: {
+        confirmUndeploy: "CONTINUE",
+        chooseCommandPath: "/aaa/one.yml",
+      },
     })
       .expectCommandToSkip("Skipped")
       .expectSkippedStackResult({

--- a/src/takomo-stacks-commands/stacks/deploy/command.ts
+++ b/src/takomo-stacks-commands/stacks/deploy/command.ts
@@ -76,6 +76,7 @@ export const deployStacksCommand: CommandHandler<
         commandPath: input.interactive ? undefined : input.commandPath,
         logger: io,
         credentialManager,
+        validateCommandRoles: false,
       }),
     )
     .then((ctx) => deployStacks(ctx, configRepository, io, input))

--- a/src/takomo-stacks-commands/stacks/undeploy/plan.ts
+++ b/src/takomo-stacks-commands/stacks/undeploy/plan.ts
@@ -95,16 +95,21 @@ export const buildStacksUndeployPlan = async (
     .filter(pruneFilter)
 
   const sortedStacks = sortStacksForUndeploy(stacksToUndeploy)
+
+  const selectedStacks = ignoreDependencies
+    ? sortedStacks.filter((stack) =>
+        isWithinCommandPath(stack.path, commandPath),
+      )
+    : sortedStacks
+
   const operations = await Promise.all(
-    sortedStacks.map((stack) =>
+    selectedStacks.map((stack) =>
       convertToUndeployOperation(stacksByPath, stack, prune),
     ),
   )
 
   return {
     prune,
-    operations: ignoreDependencies
-      ? operations.filter((o) => isWithinCommandPath(o.stack.path, commandPath))
-      : operations,
+    operations,
   }
 }


### PR DESCRIPTION
Previously, all command roles were validated by attempting to assume them. This was done even for stacks that were not selected to be in a stack deploy or undeploy operation. After this change, only command roles in stacks that are selected for an operation are validated.